### PR TITLE
Add mtbl_reader_get_* functions to retrieve trailer metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+mtbl (0.8.0)
+
+  * mtbl_reader(3): New reader getters, which expose the metadata stored
+    in the "trailer" of a mtbl file. For example: the number of bytes of
+    source data in the keys & values is available via
+    mtbl_reader_get_bytes_keys() & mtbl_reader_get_bytes_values().
+
+-- Alexey Spiridonov <lesha@fb.com>  Thu Jan 22 14:48:30 PST 2015
+    
+
 mtbl (0.7.0)
 
   * mtbl_reader(3): New reader option 'madvise_random' which may drastically

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([mtbl], [0.7.0])
+AC_INIT([mtbl], [0.8.0])
 AC_CONFIG_SRCDIR([mtbl/mtbl.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign 1.11 -Wall -Wno-portability silent-rules subdir-objects color-tests])

--- a/man/mtbl_reader.3
+++ b/man/mtbl_reader.3
@@ -2,12 +2,12 @@
 .\"     Title: mtbl_reader
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 11/18/2014
+.\"      Date: 01/22/2015
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_READER" "3" "11/18/2014" "\ \&" "\ \&"
+.TH "MTBL_READER" "3" "01/22/2015" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -80,6 +80,53 @@ mtbl_reader_options_set_madvise_random(
         struct mtbl_reader_options *\fR\fB\fIropt\fR\fR\fB,
         bool \fR\fB\fImadvise_random\fR\fR\fB);\fR
 .fi
+.sp
+Reader file metadata:
+.sp
+.nf
+\fBuint64_t
+mtbl_reader_get_index_block_offset(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBuint64_t
+mtbl_reader_get_data_block_size(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBmtbl_compression_type
+mtbl_reader_get_compression_algorithm(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBuint64_t
+mtbl_reader_get_count_entries(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBuint64_t
+mtbl_reader_get_count_data_blocks(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBuint64_t
+mtbl_reader_get_bytes_data_blocks(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBuint64_t
+mtbl_reader_get_bytes_index_block(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBuint64_t
+mtbl_reader_get_bytes_keys(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBuint64_t
+mtbl_reader_get_bytes_values(struct mtbl_reader *\fR\fB\fIr\fR\fR\fB);\fR
+.fi
 .SH "DESCRIPTION"
 .sp
 MTBL files are accessed by creating an \fBmtbl_reader\fR object, calling \fBmtbl_reader_source\fR() to obtain an \fBmtbl_source\fR handle, and using the \fBmtbl_source\fR(3) interface to read entries\&.
@@ -113,6 +160,99 @@ Specifies whether the kernel should be advised if the data access patterns are e
 This option can be explicitly overridden by setting the environment variable \fBMTBL_READER_MADVISE_RANDOM\fR to the string \fB"0"\fR (force disable) or \fB"1"\fR (force enable)\&.
 .sp
 This option only has any effect on systems that have the \fBposix_madvise\fR or \fBmadvise\fR system calls\&.
+.RE
+.SS "File metadata"
+.sp
+The functions prefixed with \fBmtbl_reader_get\fR expose metadata about the entire MTBL file:
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBmtbl_reader_get_index_block_offset()\fR
+.RS 4
+.sp
+Byte offset in the MTBL file where the index begins\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBmtbl_reader_get_data_block_size()\fR
+.RS 4
+.sp
+Size of an uncompressed data block, see \fBmtrbl_writer\fR(3)\&. ==== mtbl_reader_get_compression_algorithm() ====
+.sp
+One of the \fBcompression\fR values allowed by \fBmtrbl_writer\fR(3)\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBmtbl_reader_get_count_entries()\fR
+.RS 4
+.sp
+How many key\-value pairs are in the file\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBmtbl_reader_get_count_data_blocks()\fR
+.RS 4
+.sp
+The number of data blocks\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBmtbl_reader_get_bytes_data_blocks()\fR
+.RS 4
+.sp
+Number of bytes in used for key\-value data (as opposed to the index)\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBmtbl_reader_get_bytes_index_block()\fR
+.RS 4
+.sp
+Number of bytes used for the index\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBmtbl_reader_get_bytes_keys()\fR
+.RS 4
+.sp
+How many bytes are needed to store the concatenation of all the original, uncompressed keys\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBmtbl_reader_get_bytes_values()\fR
+.RS 4
+.sp
+How many bytes are needed to store the concatenation of all the original, uncompressed values\&.
 .RE
 .SH "RETURN VALUE"
 .sp

--- a/man/mtbl_reader.3.txt
+++ b/man/mtbl_reader.3.txt
@@ -48,6 +48,44 @@ mtbl_reader_options_set_madvise_random(
         struct mtbl_reader_options *'ropt',
         bool 'madvise_random');^
 
+Reader file metadata:
+
+[verse]
+^uint64_t
+mtbl_reader_get_index_block_offset(struct mtbl_reader *'r');^
+
+[verse]
+^uint64_t
+mtbl_reader_get_data_block_size(struct mtbl_reader *'r');^
+
+[verse]
+^mtbl_compression_type
+mtbl_reader_get_compression_algorithm(struct mtbl_reader *'r');^
+
+[verse]
+^uint64_t
+mtbl_reader_get_count_entries(struct mtbl_reader *'r');^
+
+[verse]
+^uint64_t
+mtbl_reader_get_count_data_blocks(struct mtbl_reader *'r');^
+
+[verse]
+^uint64_t
+mtbl_reader_get_bytes_data_blocks(struct mtbl_reader *'r');^
+
+[verse]
+^uint64_t
+mtbl_reader_get_bytes_index_block(struct mtbl_reader *'r');^
+
+[verse]
+^uint64_t
+mtbl_reader_get_bytes_keys(struct mtbl_reader *'r');^
+
+[verse]
+^uint64_t
+mtbl_reader_get_bytes_values(struct mtbl_reader *'r');^
+
 == DESCRIPTION ==
 
 MTBL files are accessed by creating an ^mtbl_reader^ object, calling
@@ -86,6 +124,48 @@ This option can be explicitly overridden by setting the environment variable
 
 This option only has any effect on systems that have the ^posix_madvise^ or
 ^madvise^ system calls.
+
+=== File metadata ===
+
+The functions prefixed with ^mtbl_reader_get^ expose metadata about the
+entire MTBL file:
+
+==== mtbl_reader_get_index_block_offset() ====
+
+Byte offset in the MTBL file where the index begins.
+
+==== mtbl_reader_get_data_block_size() ====
+
+Size of an uncompressed data block, see ^mtrbl_writer^(3).
+==== mtbl_reader_get_compression_algorithm() ====
+
+One of the ^compression^ values allowed by ^mtrbl_writer^(3).
+
+==== mtbl_reader_get_count_entries() ====
+
+How many key-value pairs are in the file.
+
+==== mtbl_reader_get_count_data_blocks() ====
+
+The number of data blocks.
+
+==== mtbl_reader_get_bytes_data_blocks() ====
+
+Number of bytes in used for key-value data (as opposed to the index).
+
+==== mtbl_reader_get_bytes_index_block() ====
+
+Number of bytes used for the index.
+
+==== mtbl_reader_get_bytes_keys() ====
+
+How many bytes are needed to store the concatenation of all the original,
+uncompressed keys.
+
+==== mtbl_reader_get_bytes_values() ====
+
+How many bytes are needed to store the concatenation of all the 
+original, uncompressed values.
 
 == RETURN VALUE ==
 

--- a/mtbl/libmtbl.sym
+++ b/mtbl/libmtbl.sym
@@ -70,3 +70,16 @@ LIBMTBL_0.7.0 {
 global:
         mtbl_reader_options_set_madvise_random;
 } LIBMTBL_0.6.0;
+
+LIBMTBL_0.8.0 {
+global:
+	mtbl_reader_get_index_block_offset;
+	mtbl_reader_get_data_block_size;
+	mtbl_reader_get_compression_algorithm;
+	mtbl_reader_get_count_entries;
+	mtbl_reader_get_count_data_blocks;
+	mtbl_reader_get_bytes_data_blocks;
+	mtbl_reader_get_bytes_index_block;
+	mtbl_reader_get_bytes_keys;
+	mtbl_reader_get_bytes_values;
+} LIBMTBL_0.7.0;

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -195,6 +195,35 @@ mtbl_reader_destroy(struct mtbl_reader **);
 const struct mtbl_source *
 mtbl_reader_source(struct mtbl_reader *);
 
+/* reader metadata */
+
+uint64_t
+mtbl_reader_get_index_block_offset(struct mtbl_reader *);
+
+uint64_t
+mtbl_reader_get_data_block_size(struct mtbl_reader *);
+
+mtbl_compression_type
+mtbl_reader_get_compression_algorithm(struct mtbl_reader *);
+
+uint64_t
+mtbl_reader_get_count_entries(struct mtbl_reader *);
+
+uint64_t
+mtbl_reader_get_count_data_blocks(struct mtbl_reader *);
+
+uint64_t
+mtbl_reader_get_bytes_data_blocks(struct mtbl_reader *);
+
+uint64_t
+mtbl_reader_get_bytes_index_block(struct mtbl_reader *);
+
+uint64_t
+mtbl_reader_get_bytes_keys(struct mtbl_reader *);
+
+uint64_t
+mtbl_reader_get_bytes_values(struct mtbl_reader *);
+
 /* reader options */
 
 struct mtbl_reader_options *

--- a/mtbl/reader.c
+++ b/mtbl/reader.c
@@ -478,3 +478,57 @@ reader_iter_next(void *v,
 		return (mtbl_res_success);
 	return (mtbl_res_failure);
 }
+
+uint64_t
+mtbl_reader_get_index_block_offset(struct mtbl_reader *r)
+{
+	return r->t.index_block_offset;
+}
+
+uint64_t
+mtbl_reader_get_data_block_size(struct mtbl_reader *r)
+{
+	return r->t.data_block_size;
+}
+
+mtbl_compression_type
+mtbl_reader_get_compression_algorithm(struct mtbl_reader *r)
+{
+	return r->t.compression_algorithm;
+}
+
+uint64_t
+mtbl_reader_get_count_entries(struct mtbl_reader *r)
+{
+	return r->t.count_entries;
+}
+
+uint64_t
+mtbl_reader_get_count_data_blocks(struct mtbl_reader *r)
+{
+	return r->t.count_data_blocks;
+}
+
+uint64_t
+mtbl_reader_get_bytes_data_blocks(struct mtbl_reader *r)
+{
+	return r->t.bytes_data_blocks;
+}
+
+uint64_t
+mtbl_reader_get_bytes_index_block(struct mtbl_reader *r)
+{
+	return r->t.bytes_index_block;
+}
+
+uint64_t
+mtbl_reader_get_bytes_keys(struct mtbl_reader *r)
+{
+	return r->t.bytes_keys;
+}
+
+uint64_t
+mtbl_reader_get_bytes_values(struct mtbl_reader *r)
+{
+	return r->t.bytes_values;
+}


### PR DESCRIPTION
My goal was to create an in-memory representation of the original data in an MTBL file.  To do this, it's very helpful to know the size of the source data, namely the key & value bytes, and the number of entries.

I added the other getters so that the "mtbl_info" program wouldn't have to use private APIs to do its job.

Test Plan:

```
./autogen.sh && ./configure && make
sudo make install
(for f in t/*.data; do /usr/bin/mtbl_info $f ; done) &> UBUNTU_SYS_OUTPUT 
(for f in t/*.data; do /usr/local/bin/mtbl_info $f ; done) &> NEW_OUTPUT
diff UBUNTU_SYS_OUTPUT NEW_OUTPUT 
```

The difference in error message seems acceptable:

```
1c1
< Error: lseek() failed: Invalid argument
---
> Error: mtbl_reader_init() on t/test-deb716628.data failed
```
