### PR TITLE
Allow non-MTBL data to precede MTBL data

### DIFF
--- a/man/mtbl_writer.3.txt
+++ b/man/mtbl_writer.3.txt
@@ -75,8 +75,13 @@ used instead.
 ^mtbl_writer^ objects may be created by calling ^mtbl_writer_init^() with an
 _fname_ argument specifying a filename to be created. The filename must not
 already exist on the filesystem. Or, ^mtbl_writer_init_fd^() may be called with
-an _fd_ argument specifying an open, writable file descriptor. No data may have been
-written to the file descriptor.
+an _fd_ argument specifying an open, writable file descriptor. Prior to the
+call, moving _fd_'s cursor via ^write^(2) or ^lseek^(2) will have the effect
+of reserving the file's initial bytes for non-MTBL use. MTBL will only write
+at, or above the current offset. Thereafter, only ^mtbl_writer^ may access this
+_fd_ (including closing it), and no other writes may be made to the underlying 
+file above the first offset of the MTBL data. The MTBL data must be last in the
+file.
 
 If the _wopt_ parameter to ^mtbl_writer_init^() or ^mtbl_writer_init_fd^() is
 non-NULL, the parameters specified in the ^mtbl_writer_options^ object will be

--- a/mtbl/writer.c
+++ b/mtbl/writer.c
@@ -112,6 +112,10 @@ mtbl_writer_init_fd(int orig_fd, const struct mtbl_writer_options *opt)
 		memcpy(&w->opt, opt, sizeof(*opt));
 	}
 	w->fd = fd;
+	// Start writing from the current offset. This allows mtbl's callers
+	// to reserve some initial bytes in the file.
+	w->last_offset = lseek(fd, 0, SEEK_CUR);
+	w->pending_offset = w->last_offset;
 	w->last_key = ubuf_init(256);
 	w->t.compression_algorithm = w->opt.compression_type;
 	w->t.data_block_size = w->opt.block_size;


### PR DESCRIPTION
Since the metadata block is located relative to the end of the file,
it's completely reasonable to extend the MTBL format to allow non-MTBL
data to preceded it in the file:

```
<foreign data><MTBL blocks><MTBL metadata>
```

This is very useful, for two reasons:

* One may add application-specific metadata in a prefix, while also having a valid MTBL file.
* One can create ZIP-style archives with MTBL serving as the trailing index.

#### Test Plan ####
Made a file like this:

```
int fd = open(argv[1], O_WRONLY | O_CREAT | O_EXCL, 0644);
CHECK(fd) << "Could not create " << argv[1] << " -- does it exist?";
const char* header = "Hello, world!";
CHECK(write(fd, header, strlen(header)) == (ssize_t)strlen(header));
...
auto writer = mtbl_writer_init_fd(fd, wopt);
```

Verified that `mtbl_info` and `mtbl_dump` were able to parse the resulting
file, and that all the keys I wrote were able to be retrieved.

Also checked that the "Hello, world!" prefix was intact.