### PR TITLE
DEAD-Pull-Request- `mtbl_source_get_range` supports iterating until the end

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,6 +102,11 @@ check_PROGRAMS += t/test-crc32c
 t_test_crc32c_SOURCES = t/test-crc32c.c
 t_test_crc32c_LDADD = mtbl/libmtbl.la
 
+TESTS += t/test-get-range
+check_PROGRAMS += t/test-get-range
+t_test_get_range_SOURCES = t/test-get-range.c
+t_test_get_range_LDADD = mtbl/libmtbl.la
+
 TESTS += t/test-fixed
 check_PROGRAMS += t/test-fixed
 t_test_fixed_SOURCES = t/test-fixed.c

--- a/man/mtbl_source.3
+++ b/man/mtbl_source.3
@@ -2,12 +2,12 @@
 .\"     Title: mtbl_source
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 01/31/2014
+.\"      Date: 05/24/2015
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_SOURCE" "3" "01/31/2014" "\ \&" "\ \&"
+.TH "MTBL_SOURCE" "3" "05/24/2015" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -77,7 +77,7 @@ The \fBmtbl_source\fR iterface provides an abstraction for reading key\-value en
 .sp
 \fBmtbl_source_get_prefix\fR() provides a prefix iterator which returns all entries whose keys start with \fIprefix\fR and are at least \fIlen_prefix\fR bytes long\&.
 .sp
-\fBmtbl_source_get_range\fR() provides a range iterator which returns all entries whose keys are between \fIkey0\fR and \fIkey1\fR inclusive\&.
+\fBmtbl_source_get_range\fR() provides a range iterator which returns all entries whose keys are between \fIkey0\fR and \fIkey1\fR inclusive\&. Specify \fIlen_key0\fR of 0 to iterate from the start\&. To iterate until the end, set \fIkey1\fR to NULL, and \fIlen_key1\fR to a POSITIVE number, thus distinguishing it from the empty key\&.
 .sp
 \fBmtbl_source_write\fR() is a convenience function for reading all of the entries from a source and writing them to an \fBmtbl_writer\fR object\&. It is equivalent to calling \fBmtbl_writer_add\fR() on all of the entries returned from \fBmtbl_source_iter\fR()\&.
 .SH "RETURN VALUE"

--- a/man/mtbl_source.3.txt
+++ b/man/mtbl_source.3.txt
@@ -52,7 +52,9 @@ whose key matches the key provided in the arguments _key_ and _len_key_.
 whose keys start with _prefix_ and are at least _len_prefix_ bytes long.
 
 ^mtbl_source_get_range^() provides a range iterator which returns all entries
-whose keys are between _key0_ and _key1_ inclusive.
+whose keys are between _key0_ and _key1_ inclusive. Specify _len_key0_ of 0
+to iterate from the start. To iterate until the end, set _key1_ to NULL, and
+_len_key1_ to a POSITIVE number, thus distinguishing it from the empty key.
 
 ^mtbl_source_write^() is a convenience function for reading all of the entries
 from a source and writing them to an ^mtbl_writer^ object. It is equivalent to

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -1,5 +1,6 @@
 test-block_builder
 test-crc32c
+test-get-range
 test-fixed
 test-metadata
 test-varint

--- a/t/test-get-range.c
+++ b/t/test-get-range.c
@@ -1,0 +1,100 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <mtbl.h>
+
+void check(bool ok, const char* message);
+void check_next(struct mtbl_iter* it, char expected);
+
+int main(int argc, char **argv) {
+    char path[] = "/tmp/mtbl-test-get-range-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd == -1) {
+        fprintf(
+            stderr, "Failed to make tempfile at %s (error %d): %s\n",
+            path, errno, strerror(errno)
+        );
+        return 1;
+    }
+     
+    struct mtbl_writer_options* wopt = mtbl_writer_options_init();
+    check(wopt, "mtbl_writer_options_init");
+    struct mtbl_writer* writer = mtbl_writer_init_fd(fd, wopt);
+    check(writer, "mtbl_writer_init_fd");
+    mtbl_writer_options_destroy(&wopt);
+    
+    for (unsigned char c = 'a'; c < 'g'; ++c) {
+        check(
+            mtbl_writer_add(writer, &c, 1, &c, 1) == mtbl_res_success,
+            "mtbl_writer_add"
+        );
+    }
+    
+    mtbl_writer_destroy(&writer);
+    check(close(fd) == 0, "close");
+    
+    struct mtbl_reader* reader = mtbl_reader_init(path, NULL);
+    check(reader, "mtbl_reader_init");
+
+    const struct mtbl_source* source = mtbl_reader_source(reader);
+    
+    struct mtbl_iter* it =
+        mtbl_source_get_range(source, (uint8_t*)"b", 1, (uint8_t*)"cc", 2);
+    check_next(it, 'b');
+    check_next(it, 'c');
+    check_next(it, 0);
+    mtbl_iter_destroy(&it);
+
+    // A zero-length null "end" is equivalent to an empty key.
+    it = mtbl_source_get_range(source, (uint8_t*)"b", 1, NULL, 0);
+    check_next(it, 0);
+    mtbl_iter_destroy(&it);
+
+    // A positive-length null "end" means "iterate until the end".
+    it = mtbl_source_get_range(source, (uint8_t*)"b", 1, NULL, 1);
+    for (char c = 'b'; c < 'g'; ++c) {
+        check_next(it, c);
+    }
+    check_next(it, 0);
+    mtbl_iter_destroy(&it);
+
+    // A zero-length key always sorts first
+    it = mtbl_source_get_range(source, NULL, 0, (uint8_t*)"b", 1);
+    check_next(it, 'a');
+    check_next(it, 'b');
+    check_next(it, 0);
+    mtbl_iter_destroy(&it);
+
+    mtbl_reader_destroy(&reader);
+      
+    return 0;
+}
+
+void check(bool ok, const char* err) {
+    if (!ok) {
+        if (errno) {
+            fprintf(stderr, "Error %d: %s: %s", errno, err, strerror(errno));
+        } else {
+            fprintf(stderr, "Error: %s", err);
+        }
+        exit(1);
+    }
+}
+
+void check_next(struct mtbl_iter* it, char expected) {
+    uint8_t e = expected;
+    const uint8_t* key;
+    const uint8_t* val;
+    size_t key_len, val_len;
+    mtbl_res res = mtbl_iter_next(it, &key, &key_len, &val, &val_len);
+    if (expected) {
+        check(res == mtbl_res_success, "mtbl_iter_next success");
+        check(key_len == 1 && val_len == 1, "key or value length != 1");
+        check(key[0] == e && val[0] == e, "wrong key or value");
+    } else {
+        check(res == mtbl_res_failure, "mtbl_iter_next end");
+    }
+}


### PR DESCRIPTION
**Summary:** Supporting semi-infinite intervals is a natural extension for `get_range`. I want it because I want `mtbl` to be API-compatible with C++ `std::map`, so this gives me `std::lower_bound`.

**Test Plan:**
- `$EDITOR $(git grep -il get_range)` -- confirmed that only `reader.c` inspects `key1` and `len_key1`.
- `make check` passed my snazzy new unit test
- viewed the new `man` page
