### PR TITLE
reader: Don't keep an open file descriptor corresponding to the mmap()'d file

### DIFF
--- a/mtbl/reader.c
+++ b/mtbl/reader.c
@@ -42,7 +42,6 @@ struct mtbl_reader_options {
 };
 
 struct mtbl_reader {
-	int				fd;
 	struct mtbl_metadata		m;
 	uint8_t				*data;
 	size_t				len_data;
@@ -133,36 +132,28 @@ reader_init_madvise(struct mtbl_reader *r)
 }
 
 struct mtbl_reader *
-mtbl_reader_init_fd(int orig_fd, const struct mtbl_reader_options *opt)
+mtbl_reader_init_fd(int fd, const struct mtbl_reader_options *opt)
 {
 	struct mtbl_reader *r;
 	struct stat ss;
 	size_t metadata_offset;
-	int fd;
 
 	size_t index_len;
 	uint32_t index_crc;
 	uint8_t *index_data;
 
-	assert(orig_fd >= 0);
-	fd = dup(orig_fd);
-	assert(fd >= 0);
 	int ret = fstat(fd, &ss);
 	assert(ret == 0);
 
-	if (ss.st_size < MTBL_METADATA_SIZE) {
-		close(fd);
+	if (ss.st_size < MTBL_METADATA_SIZE)
 		return (NULL);
-	}
 
 	r = my_calloc(1, sizeof(*r));
 	if (opt != NULL)
 		memcpy(&r->opt, opt, sizeof(*opt));
-	r->fd = fd;
 	r->len_data = ss.st_size;
-	r->data = mmap(NULL, r->len_data, PROT_READ, MAP_PRIVATE, r->fd, 0);
+	r->data = mmap(NULL, r->len_data, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (r->data == MAP_FAILED) {
-		close(r->fd);
 		free(r);
 		return (NULL);
 	}
@@ -209,7 +200,6 @@ mtbl_reader_destroy(struct mtbl_reader **r)
 	if (*r != NULL) {
 		block_destroy(&(*r)->index);
 		munmap((*r)->data, (*r)->len_data);
-		close((*r)->fd);
 		mtbl_source_destroy(&(*r)->source);
 		free(*r);
 		*r = NULL;


### PR DESCRIPTION
Previously, mtbl_reader_init_fd() would dup() the file descriptor passed
by the caller, so that we would always have an open file descriptor
corresponding to the file that we mmap(). It turns out that this is not
actually necessary. Per POSIX:

    The mmap() function shall add an extra reference to the file
    associated with the file descriptor fildes which is not removed by a
    subsequent close() on that file descriptor. This reference shall be
    removed when there are no more mappings to the file.

(http://pubs.opengroup.org/onlinepubs/9699919799/functions/mmap.html)

So, remove the 'fd' field of struct mtbl_reader, and stop keeping
dup()'d file descriptors in mtbl_reader_init_fd().

This change should increase the number of MTBL files that can be
simultaneously opened (with no special permissions or process limit
changes) beyond the open file descriptor limit.