### PR TITLE
mtbl_dump: Add silent ("-s") option

### DIFF
--- a/man/mtbl_dump.1
+++ b/man/mtbl_dump.1
@@ -2,12 +2,12 @@
 .\"     Title: mtbl_dump
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 01/31/2014
+.\"      Date: 07/17/2015
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_DUMP" "1" "01/31/2014" "\ \&" "\ \&"
+.TH "MTBL_DUMP" "1" "07/17/2015" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,13 @@
 mtbl_dump \- print key\-value entries from an MTBL file
 .SH "SYNOPSIS"
 .sp
-\fBmtbl_dump\fR \fIFILE\fR
+\fBmtbl_dump\fR [\fI\-s\fR] \fIFILE\fR
 .SH "DESCRIPTION"
 .sp
 \fBmtbl_dump\fR(1) prints all key\-value entries from an MTBL file to stdout, in file order\&. Each entry is printed on its own line, with double quotes surrounding the key and the value, with a single space character separating the two\&. Unprintable characters and embedded double quote characters are escaped using the Python string literal syntax\&.
+.SH "OPTIONS"
+.PP
+\fB\-s\fR
+.RS 4
+Silent mode (don\(cqt output anything)\&. Useful for benchmarking\&.
+.RE

--- a/man/mtbl_dump.1.txt
+++ b/man/mtbl_dump.1.txt
@@ -6,7 +6,7 @@ mtbl_dump - print key-value entries from an MTBL file
 
 == SYNOPSIS ==
 
-^mtbl_dump^ 'FILE'
+^mtbl_dump^ ['-s'] 'FILE'
 
 == DESCRIPTION ==
 
@@ -15,3 +15,8 @@ file order. Each entry is printed on its own line, with double quotes
 surrounding the key and the value, with a single space character separating
 the two. Unprintable characters and embedded double quote characters are
 escaped using the Python string literal syntax.
+
+== OPTIONS ==
+
+^-s^::
+    Silent mode (don't output anything). Useful for benchmarking.

--- a/src/mtbl_dump.c
+++ b/src/mtbl_dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014 by Farsight Security, Inc.
+ * Copyright (c) 2012, 2014-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <mtbl.h>
 
 #include "libmy/print_string.h"
 
 static bool
-dump(const char *fname)
+dump(const char *fname, const bool silent)
 {
 	const uint8_t *key, *val;
 	size_t len_key, len_val;
@@ -37,6 +39,8 @@ dump(const char *fname)
 
 	it = mtbl_source_iter(mtbl_reader_source(r));
 	while (mtbl_iter_next(it, &key, &len_key, &val, &len_val)) {
+		if (silent)
+			continue;
 		print_string(key, len_key, stdout);
 		fputc(' ', stdout);
 		print_string(val, len_val, stdout);
@@ -49,18 +53,34 @@ dump(const char *fname)
 	return (true);
 }
 
+static void
+usage(void)
+{
+	fprintf(stderr, "Usage: mtbl_dump [-s] <MTBL FILE>\n");
+	exit(EXIT_FAILURE);
+}
+
 int
 main(int argc, char **argv)
 {
 	char *fname;
+	bool silent = false;
 
-	if (argc != 2) {
-		fprintf(stderr, "Usage: %s <MTBL FILE>\n", argv[0]);
-		exit(EXIT_FAILURE);
+	int c;
+	while ((c = getopt(argc, argv, "s")) != -1) {
+		switch (c) {
+		case 's':
+			silent = true;
+			break;
+		default:
+			usage();
+		}
 	}
-	fname = argv[1];
+	if (optind >= argc)
+		usage();
+	fname = argv[optind];
 
-	if (!dump(fname))
+	if (!dump(fname, silent))
 		return (EXIT_FAILURE);
 	return (EXIT_SUCCESS);
 }


### PR DESCRIPTION
This commit adds a -s (silent) flag to mtbl_dump which omits the actual
dump output. This is useful when focusing on decompression performance,
since the cost of formatting the output and writing it to stdout is
significant.