### PR TITLE
OS X compatibility

### DIFF
--- a/mtbl/fileset.c
+++ b/mtbl/fileset.c
@@ -20,6 +20,49 @@
 
 #include "libmy/my_fileset.h"
 
+/* OS X compatibility support based on code from Mathias Panzenböck */
+
+#ifdef __MACH__
+#include "mach_gettime.h"
+#include <mach/mach_time.h>
+
+#define MT_NANO (+1.0E-9)
+#define MT_GIGA UINT64_C(1000000000)
+
+static double mt_timebase = 0.0;
+static uint64_t mt_timestart = 0;
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+    kern_return_t retval = KERN_SUCCESS;
+    if( clk_id == TIMER_ABSTIME) {
+        if (!mt_timestart) { 
+            mach_timebase_info_data_t tb = { 0 };
+            mach_timebase_info(&tb);
+            mt_timebase = tb.numer;
+            mt_timebase /= tb.denom;
+            mt_timestart = mach_absolute_time();
+        }
+
+        double diff = (mach_absolute_time() - mt_timestart) * mt_timebase;
+        tp->tv_sec = diff * MT_NANO;
+        tp->tv_nsec = diff - (tp->tv_sec * MT_GIGA);
+    }
+    else { 
+        clock_serv_t cclock;
+        mach_timespec_t mts;
+
+        host_get_clock_service(mach_host_self(), clk_id, &cclock);
+        retval = clock_get_time(cclock, &mts);
+        mach_port_deallocate(mach_task_self(), cclock);
+
+        tp->tv_sec = mts.tv_sec;
+        tp->tv_nsec = mts.tv_nsec;
+    }
+
+    return retval;
+}
+#endif
+
 struct mtbl_fileset_options {
 	size_t				reload_interval;
 	mtbl_merge_func			merge;

--- a/mtbl/mach_gettime.h
+++ b/mtbl/mach_gettime.h
@@ -1,0 +1,19 @@
+/* enables use of clock_gettime() on OS X, based on code by Mathias Panzenböck */
+
+#include <sys/types.h>
+#include <sys/_types/_timespec.h>
+#include <mach/mach.h>
+#include <mach/clock.h>
+
+#ifndef mach_time_h
+#define mach_time_h
+
+#define TIMER_ABSTIME -1
+#define CLOCK_REALTIME CALENDAR_CLOCK
+#define CLOCK_MONOTONIC SYSTEM_CLOCK
+
+typedef int clockid_t;
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp);
+
+#endif

--- a/mtbl/mtbl-private.h
+++ b/mtbl/mtbl-private.h
@@ -146,4 +146,27 @@ bytes_compare(const uint8_t *a, size_t len_a,
 	return (ret);
 }
 
+/* OS X compatibility based on code from Mathias Panzenböck */
+
+#if defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define htobe16(x) OSSwapHostToBigInt16(x) 
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define __BYTE_ORDER    BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN    PDP_ENDIAN
+#endif
+
+
 #endif /* MTBL_PRIVATE_H */


### PR DESCRIPTION
adds supporting code to enable `mtbl` to build/run on OS X. Tested on El Capitan & verified with `make check`