### PR TITLE
Add zstd compression support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,12 @@ before_install:
 
 install:
   # Linux
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get -qq install liblz4-dev libsnappy-dev zlib1g-dev; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get -qq install liblz4-dev libsnappy-dev libzstd-dev zlib1g-dev; fi
 
   # OS X
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install lz4; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install snappy; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install zstd; fi
 
 script:
   - ./autogen.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,8 @@ AM_CPPFLAGS = \
 	-I${top_srcdir}/mtbl
 AM_CFLAGS = \
 	${my_CFLAGS} \
-	$(liblz4_CFLAGS)
+	$(liblz4_CFLAGS) \
+	$(libzstd_CFLAGS)
 AM_LDFLAGS =
 
 #
@@ -54,7 +55,7 @@ mtbl_libmtbl_la_SOURCES = \
 	mtbl/varint.c \
 	mtbl/writer.c
 
-mtbl_libmtbl_la_LIBADD = -lsnappy -lz $(liblz4_LIBS)
+mtbl_libmtbl_la_LIBADD = -lsnappy -lz $(liblz4_LIBS) $(libzstd_LIBS)
 mtbl_libmtbl_la_LDFLAGS = $(AM_LDFLAGS) \
 	-version-info $(LIBMTBL_VERSION_INFO)
 if HAVE_LD_VERSION_SCRIPT

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ else
 fi
 
 PKG_CHECK_MODULES([liblz4], [liblz4 > 129])
+PKG_CHECK_MODULES([libzstd], [libzstd >= 0.8.0])
 
 AC_C_BIGENDIAN
 

--- a/man/mtbl_info.1
+++ b/man/mtbl_info.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mtbl_info
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 07/17/2015
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 12/11/2016
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_INFO" "1" "07/17/2015" "\ \&" "\ \&"
+.TH "MTBL_INFO" "1" "12/11/2016" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -54,6 +54,6 @@ mtbl_info \- display information about an MTBL file
 .sp
 \fIvalue bytes\fR \(em the total number of bytes that all values in the file would occupy if stored end\-to\-end in a byte array with no delimiters\&.
 .sp
-\fIcompression algorithm\fR \(em the algorithm used to compress data blocks\&. Possible values are "none", "snappy", "zlib", "lz4", and "lz4hc"\&.
+\fIcompression algorithm\fR \(em the algorithm used to compress data blocks\&. Possible values are "none", "snappy", "zlib", "lz4", "lz4hc", and "zstd"\&.
 .sp
 \fIcompactness\fR \(em a rough metric comparing the total number of bytes in the key\-value entries with the total size of the MTBL file\&. It is calculated as (file size) / (key bytes + value bytes), and thus takes into account the gains of data block compression and prefix key compression against the overhead of the index, metadata, and data block offset arrays\&.

--- a/man/mtbl_info.1.txt
+++ b/man/mtbl_info.1.txt
@@ -36,7 +36,7 @@ occupy if stored end-to-end in a byte array with no delimiters.
 occupy if stored end-to-end in a byte array with no delimiters.
 
 'compression algorithm' -- the algorithm used to compress data blocks.
-Possible values are "none", "snappy", "zlib", "lz4", and "lz4hc".
+Possible values are "none", "snappy", "zlib", "lz4", "lz4hc", and "zstd".
 
 'compactness' -- a rough metric comparing the total number of bytes in the
 key-value entries with the total size of the MTBL file. It is calculated as

--- a/man/mtbl_writer.3
+++ b/man/mtbl_writer.3
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mtbl_writer
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 07/17/2015
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 12/11/2016
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_WRITER" "3" "07/17/2015" "\ \&" "\ \&"
+.TH "MTBL_WRITER" "3" "12/11/2016" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -110,7 +110,7 @@ If the \fIwopt\fR parameter to \fBmtbl_writer_init\fR() or \fBmtbl_writer_init_f
 \fBcompression\fR
 .RS 4
 .sp
-Specifies the compression algorithm to use on data blocks\&. Possible values are \fBMTBL_COMPRESSION_NONE\fR, \fBMTBL_COMPRESSION_SNAPPY\fR, \fBMTBL_COMPRESSION_LZ4\fR, \fBMTBL_COMPRESSION_LZ4HC\fR, or \fBMTBL_COMPRESSION_ZLIB\fR (the default)\&.
+Specifies the compression algorithm to use on data blocks\&. Possible values are \fBMTBL_COMPRESSION_NONE\fR, \fBMTBL_COMPRESSION_SNAPPY\fR, \fBMTBL_COMPRESSION_LZ4\fR, \fBMTBL_COMPRESSION_LZ4HC\fR, \fBMTBL_COMPRESSION_ZSTD\fR, or \fBMTBL_COMPRESSION_ZLIB\fR (the default)\&.
 .RE
 .sp
 .it 1 an-trap

--- a/man/mtbl_writer.3
+++ b/man/mtbl_writer.3
@@ -78,6 +78,13 @@ mtbl_writer_options_set_compression(
 .sp
 .nf
 \fBvoid
+mtbl_writer_options_set_compression_level(
+        struct mtbl_writer_options *\fR\fB\fIwopt\fR\fR\fB,
+        int \fR\fB\fIcompression_level\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBvoid
 mtbl_writer_options_set_block_size(
         struct mtbl_writer_options *\fR\fB\fIwopt\fR\fR\fB,
         size_t \fR\fB\fIblock_size\fR\fR\fB);\fR
@@ -111,6 +118,17 @@ If the \fIwopt\fR parameter to \fBmtbl_writer_init\fR() or \fBmtbl_writer_init_f
 .RS 4
 .sp
 Specifies the compression algorithm to use on data blocks\&. Possible values are \fBMTBL_COMPRESSION_NONE\fR, \fBMTBL_COMPRESSION_SNAPPY\fR, \fBMTBL_COMPRESSION_LZ4\fR, \fBMTBL_COMPRESSION_LZ4HC\fR, \fBMTBL_COMPRESSION_ZSTD\fR, or \fBMTBL_COMPRESSION_ZLIB\fR (the default)\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBcompression_level\fR
+.RS 4
+.sp
+Specifies the compression level to use on data blocks, if the selected compression algorithm supports different compression levels\&. The compression algorithms which support different compression levels are \fBMTBL_COMPRESSION_LZ4HC\fR (0\-16), \fBMTBL_COMPRESSION_ZSTD\fR (1\-22), and \fBMTBL_COMPRESSION_ZLIB\fR (0\-9)\&. Other compression algorithms ignore this option, and compression levels outside the ranges supported by the algorithm will be silently clamped to the minimum or maximum supported level\&. If not specified, a reasonable default will be used\&.
 .RE
 .sp
 .it 1 an-trap

--- a/man/mtbl_writer.3.txt
+++ b/man/mtbl_writer.3.txt
@@ -46,6 +46,12 @@ mtbl_writer_options_set_compression(
 
 [verse]
 ^void
+mtbl_writer_options_set_compression_level(
+        struct mtbl_writer_options *'wopt',
+        int 'compression_level');^
+
+[verse]
+^void
 mtbl_writer_options_set_block_size(
         struct mtbl_writer_options *'wopt',
         size_t 'block_size');^
@@ -94,6 +100,16 @@ Specifies the compression algorithm to use on data blocks. Possible values are
 ^MTBL_COMPRESSION_NONE^, ^MTBL_COMPRESSION_SNAPPY^, ^MTBL_COMPRESSION_LZ4^,
 ^MTBL_COMPRESSION_LZ4HC^, ^MTBL_COMPRESSION_ZSTD^, or ^MTBL_COMPRESSION_ZLIB^
 (the default).
+
+==== compression_level ====
+Specifies the compression level to use on data blocks, if the selected
+compression algorithm supports different compression levels. The compression
+algorithms which support different compression levels are
+^MTBL_COMPRESSION_LZ4HC^ (0-16), ^MTBL_COMPRESSION_ZSTD^ (1-22), and
+^MTBL_COMPRESSION_ZLIB^ (0-9). Other compression algorithms ignore this option,
+and compression levels outside the ranges supported by the algorithm will be
+silently clamped to the minimum or maximum supported level. If not specified, a
+reasonable default will be used.
 
 ==== block_size ====
 The maximum size of uncompressed data blocks, specified in bytes. The default

--- a/man/mtbl_writer.3.txt
+++ b/man/mtbl_writer.3.txt
@@ -92,7 +92,8 @@ configured into the ^mtbl_writer^ object.
 ==== compression ====
 Specifies the compression algorithm to use on data blocks. Possible values are
 ^MTBL_COMPRESSION_NONE^, ^MTBL_COMPRESSION_SNAPPY^, ^MTBL_COMPRESSION_LZ4^,
-^MTBL_COMPRESSION_LZ4HC^, or ^MTBL_COMPRESSION_ZLIB^ (the default).
+^MTBL_COMPRESSION_LZ4HC^, ^MTBL_COMPRESSION_ZSTD^, or ^MTBL_COMPRESSION_ZLIB^
+(the default).
 
 ==== block_size ====
 The maximum size of uncompressed data blocks, specified in bytes. The default

--- a/mtbl/libmtbl.sym
+++ b/mtbl/libmtbl.sym
@@ -89,3 +89,9 @@ global:
         mtbl_metadata_bytes_keys;
         mtbl_metadata_bytes_values;
 } LIBMTBL_0.7.0;
+
+LIBMTBL_1.0.0 {
+global:
+        mtbl_compress_level;
+        mtbl_writer_options_set_compression_level;
+} LIBMTBL_0.8.0;

--- a/mtbl/mtbl-private.h
+++ b/mtbl/mtbl-private.h
@@ -97,10 +97,12 @@ mtbl_res _mtbl_compress_lz4	(const uint8_t *, const size_t, uint8_t **, size_t *
 mtbl_res _mtbl_compress_lz4hc	(const uint8_t *, const size_t, uint8_t **, size_t *);
 mtbl_res _mtbl_compress_snappy	(const uint8_t *, const size_t, uint8_t **, size_t *);
 mtbl_res _mtbl_compress_zlib	(const uint8_t *, const size_t, uint8_t **, size_t *);
+mtbl_res _mtbl_compress_zstd	(const uint8_t *, const size_t, uint8_t **, size_t *);
 
 mtbl_res _mtbl_decompress_lz4	(const uint8_t *, const size_t, uint8_t **, size_t *);
 mtbl_res _mtbl_decompress_snappy(const uint8_t *, const size_t, uint8_t **, size_t *);
 mtbl_res _mtbl_decompress_zlib	(const uint8_t *, const size_t, uint8_t **, size_t *);
+mtbl_res _mtbl_decompress_zstd	(const uint8_t *, const size_t, uint8_t **, size_t *);
 
 /* metadata */
 

--- a/mtbl/mtbl-private.h
+++ b/mtbl/mtbl-private.h
@@ -44,6 +44,7 @@
 #define MTBL_METADATA_SIZE		512
 
 #define DEFAULT_COMPRESSION_TYPE	MTBL_COMPRESSION_ZLIB
+#define DEFAULT_COMPRESSION_LEVEL	(-10000)
 #define DEFAULT_BLOCK_RESTART_INTERVAL	16
 #define DEFAULT_BLOCK_SIZE		8192
 #define MIN_BLOCK_SIZE			1024
@@ -94,10 +95,10 @@ bool block_builder_empty(struct block_builder *);
 /* compression */
 
 mtbl_res _mtbl_compress_lz4	(const uint8_t *, const size_t, uint8_t **, size_t *);
-mtbl_res _mtbl_compress_lz4hc	(const uint8_t *, const size_t, uint8_t **, size_t *);
+mtbl_res _mtbl_compress_lz4hc	(const uint8_t *, const size_t, uint8_t **, size_t *, int);
 mtbl_res _mtbl_compress_snappy	(const uint8_t *, const size_t, uint8_t **, size_t *);
-mtbl_res _mtbl_compress_zlib	(const uint8_t *, const size_t, uint8_t **, size_t *);
-mtbl_res _mtbl_compress_zstd	(const uint8_t *, const size_t, uint8_t **, size_t *);
+mtbl_res _mtbl_compress_zlib	(const uint8_t *, const size_t, uint8_t **, size_t *, int);
+mtbl_res _mtbl_compress_zstd	(const uint8_t *, const size_t, uint8_t **, size_t *, int);
 
 mtbl_res _mtbl_decompress_lz4	(const uint8_t *, const size_t, uint8_t **, size_t *);
 mtbl_res _mtbl_decompress_snappy(const uint8_t *, const size_t, uint8_t **, size_t *);

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014-2015 by Farsight Security, Inc.
+ * Copyright (c) 2012-2016 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ typedef enum {
 	MTBL_COMPRESSION_ZLIB = 2,
 	MTBL_COMPRESSION_LZ4 = 3,
 	MTBL_COMPRESSION_LZ4HC = 4,
+	MTBL_COMPRESSION_ZSTD = 5,
 } mtbl_compression_type;
 
 mtbl_res

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -50,6 +50,15 @@ mtbl_compress(
 	size_t *output_size);
 
 mtbl_res
+mtbl_compress_level(
+	mtbl_compression_type,
+	int compression_level,
+	const uint8_t *input,
+	const size_t input_size,
+	uint8_t **output,
+	size_t *output_size);
+
+mtbl_res
 mtbl_decompress(
 	mtbl_compression_type,
 	const uint8_t *input,
@@ -198,6 +207,11 @@ void
 mtbl_writer_options_set_compression(
 	struct mtbl_writer_options *,
 	mtbl_compression_type);
+
+void
+mtbl_writer_options_set_compression_level(
+	struct mtbl_writer_options *,
+	int);
 
 void
 mtbl_writer_options_set_block_size(

--- a/mtbl/writer.c
+++ b/mtbl/writer.c
@@ -77,7 +77,9 @@ mtbl_writer_options_set_compression(struct mtbl_writer_options *opt,
 	       compression_type == MTBL_COMPRESSION_SNAPPY	||
 	       compression_type == MTBL_COMPRESSION_ZLIB	||
 	       compression_type == MTBL_COMPRESSION_LZ4		||
-	       compression_type == MTBL_COMPRESSION_LZ4HC);
+	       compression_type == MTBL_COMPRESSION_LZ4HC	||
+	       compression_type == MTBL_COMPRESSION_ZSTD
+	);
 	opt->compression_type = compression_type;
 }
 

--- a/mtbl/writer.c
+++ b/mtbl/writer.c
@@ -254,31 +254,18 @@ _mtbl_writer_writeblock(struct mtbl_writer *w,
 
 	block_builder_finish(b, &raw_contents, &raw_contents_size);
 
-	switch (compression_type) {
-	case MTBL_COMPRESSION_NONE:
+	if (compression_type == MTBL_COMPRESSION_NONE) {
 		block_contents = raw_contents;
 		block_contents_size = raw_contents_size;
-		break;
-	case MTBL_COMPRESSION_LZ4:
-		res = _mtbl_compress_lz4(raw_contents, raw_contents_size,
-					 &block_contents, &block_contents_size);
+	} else {
+		res = mtbl_compress(
+			compression_type,
+			raw_contents,
+			raw_contents_size,
+			&block_contents,
+			&block_contents_size
+		);
 		assert(res == mtbl_res_success);
-		break;
-	case MTBL_COMPRESSION_LZ4HC:
-		res = _mtbl_compress_lz4hc(raw_contents, raw_contents_size,
-					   &block_contents, &block_contents_size);
-		assert(res == mtbl_res_success);
-		break;
-	case MTBL_COMPRESSION_SNAPPY:
-		res = _mtbl_compress_snappy(raw_contents, raw_contents_size,
-					    &block_contents, &block_contents_size);
-		assert(res == mtbl_res_success);
-		break;
-	case MTBL_COMPRESSION_ZLIB:
-		res = _mtbl_compress_zlib(raw_contents, raw_contents_size,
-					  &block_contents, &block_contents_size);
-		assert(res == mtbl_res_success);
-		break;
 	}
 
 	assert(block_contents_size < UINT_MAX);

--- a/mtbl/writer.c
+++ b/mtbl/writer.c
@@ -21,6 +21,7 @@
 
 struct mtbl_writer_options {
 	mtbl_compression_type		compression_type;
+	int				compression_level;
 	size_t				block_size;
 	size_t				block_restart_interval;
 };
@@ -55,6 +56,7 @@ mtbl_writer_options_init(void)
 	struct mtbl_writer_options *opt;
 	opt = my_calloc(1, sizeof(*opt));
 	opt->compression_type = DEFAULT_COMPRESSION_TYPE;
+	opt->compression_level = DEFAULT_COMPRESSION_LEVEL;
 	opt->block_size = DEFAULT_BLOCK_SIZE;
 	opt->block_restart_interval = DEFAULT_BLOCK_RESTART_INTERVAL;
 	return (opt);
@@ -81,6 +83,13 @@ mtbl_writer_options_set_compression(struct mtbl_writer_options *opt,
 	       compression_type == MTBL_COMPRESSION_ZSTD
 	);
 	opt->compression_type = compression_type;
+}
+
+void
+mtbl_writer_options_set_compression_level(struct mtbl_writer_options *opt,
+					  int compression_level)
+{
+	opt->compression_level = compression_level;
 }
 
 void
@@ -259,9 +268,19 @@ _mtbl_writer_writeblock(struct mtbl_writer *w,
 	if (compression_type == MTBL_COMPRESSION_NONE) {
 		block_contents = raw_contents;
 		block_contents_size = raw_contents_size;
-	} else {
+	} else if (w->opt.compression_level == DEFAULT_COMPRESSION_LEVEL) {
 		res = mtbl_compress(
 			compression_type,
+			raw_contents,
+			raw_contents_size,
+			&block_contents,
+			&block_contents_size
+		);
+		assert(res == mtbl_res_success);
+	} else {
+		res = mtbl_compress_level(
+			compression_type,
+			w->opt.compression_level,
 			raw_contents,
 			raw_contents_size,
 			&block_contents,

--- a/src/mtbl_merge.c
+++ b/src/mtbl_merge.c
@@ -72,7 +72,7 @@ usage(void)
 		"<SIZE> is the uncompressed data block size hint, in bytes.\n"
 		"The default value if unspecified is 8192 bytes (8 kilobytes).\n"
 		"\n"
-		"<COMPRESSION> is one of none, snappy, zlib, lz4, or lz4hc.\n"
+		"<COMPRESSION> is one of none, snappy, zlib, lz4, lz4hc, or zstd.\n"
 		"The default compression type if unspecified is zlib.\n"
 		"\n"
 		,

--- a/t/test-compression.sh
+++ b/t/test-compression.sh
@@ -18,6 +18,7 @@ for compression_type in \
     zlib \
     lz4 \
     lz4hc \
+    zstd \
 ; do
     echo "$0: Testing compression type ${compression_type}"
     "${top_builddir}/t/test-compression" "${compression_type}"


### PR DESCRIPTION
Hi,

This branch adds `zstd` compression support to `mtbl`. `zstd` is a compression algorithm which out-performs `zlib`, providing stronger compression ratios and faster decompression (see http://facebook.github.io/zstd/ for details). The minimum required version is `zstd` 0.8.0, since that release finalized the compression format. I also added the ability to configure the compression level to the API.

Note that I guessed the next mtbl release version (1.0.0) when updating `mtbl/libmtbl.sym`. If I didn't guess correctly, please update that file when making the next release.

Thanks!