### PR TITLE
File format version 2

### DIFF
--- a/man/mtbl_metadata.3
+++ b/man/mtbl_metadata.3
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mtbl_metadata
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 02/03/2015
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 02/10/2017
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_METADATA" "3" "02/03/2015" "\ \&" "\ \&"
+.TH "MTBL_METADATA" "3" "02/10/2017" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -32,6 +32,11 @@ mtbl_metadata \- get MTBL file metadata
 .SH "SYNOPSIS"
 .sp
 \fB#include <mtbl\&.h>\fR
+.sp
+.nf
+\fBmtbl_file_version
+mtbl_metadata_file_version(const struct mtbl_metadata *\fR\fB\fIm\fR\fR\fB);\fR
+.fi
 .sp
 .nf
 \fBuint64_t
@@ -81,6 +86,9 @@ mtbl_metadata_bytes_values(const struct mtbl_metadata *\fR\fB\fIm\fR\fR\fB);\fR
 .sp
 An \fBmtbl_metadata\fR object may be obtained from an \fBmtbl_reader\fR(3)\&. Its accessors export attributes and file statistics that are recorded in the metadata block\&.
 .SH "RETURN VALUE"
+.SS "mtbl_metadata_file_version()"
+.sp
+File format version of the MTBL file\&. Either MTBL_FORMAT_V1 or MTBL_FORMAT_V2\&.
 .SS "mtbl_metadata_index_block_offset()"
 .sp
 Byte offset in the MTBL file where the index begins\&.

--- a/man/mtbl_metadata.3.txt
+++ b/man/mtbl_metadata.3.txt
@@ -9,6 +9,10 @@ mtbl_metadata - get MTBL file metadata
 ^#include <mtbl.h>^
 
 [verse]
+^mtbl_file_version
+mtbl_metadata_file_version(const struct mtbl_metadata *'m');^
+
+[verse]
 ^uint64_t
 mtbl_metadata_index_block_offset(const struct mtbl_metadata *'m');^
 
@@ -51,6 +55,10 @@ Its accessors export attributes and file statistics that are recorded in the
 metadata block.
 
 == RETURN VALUE ==
+
+=== mtbl_metadata_file_version() ===
+
+File format version of the MTBL file. Either MTBL_FORMAT_V1 or MTBL_FORMAT_V2.
 
 === mtbl_metadata_index_block_offset() ===
 

--- a/mtbl/libmtbl.sym
+++ b/mtbl/libmtbl.sym
@@ -89,3 +89,7 @@ global:
         mtbl_metadata_bytes_keys;
         mtbl_metadata_bytes_values;
 } LIBMTBL_0.7.0;
+
+LIBMTBL_1.0.0 {
+        mtbl_metadata_file_version;
+} LIBMTBL_0.8.0;

--- a/mtbl/metadata.c
+++ b/mtbl/metadata.c
@@ -45,7 +45,11 @@ metadata_read(const uint8_t *buf, struct mtbl_metadata *m)
 	const uint8_t *p = buf;
 
 	magic = mtbl_fixed_decode32(buf + MTBL_METADATA_SIZE - sizeof(uint32_t));
-	if (magic != MTBL_MAGIC)
+	if (magic == MTBL_MAGIC_V1)
+		m->file_version = MTBL_FORMAT_V1;
+	else if (magic == MTBL_MAGIC)
+		m->file_version = MTBL_FORMAT_V2;
+	else
 		return (false);
 
 	m->index_block_offset = mtbl_fixed_decode64(p); p += 8;
@@ -60,6 +64,12 @@ metadata_read(const uint8_t *buf, struct mtbl_metadata *m)
 
 	return (true);
 
+}
+
+mtbl_file_version
+mtbl_metadata_file_version(const struct mtbl_metadata *m)
+{
+	return m->file_version;
 }
 
 uint64_t

--- a/mtbl/mtbl-private.h
+++ b/mtbl/mtbl-private.h
@@ -40,7 +40,8 @@
 #include "libmy/my_alloc.h"
 #include "libmy/my_byteorder.h"
 
-#define MTBL_MAGIC			0x77846676
+#define MTBL_MAGIC_V1			0x77846676
+#define MTBL_MAGIC			0x4D54424C
 #define MTBL_METADATA_SIZE		512
 
 #define DEFAULT_COMPRESSION_TYPE	MTBL_COMPRESSION_ZLIB
@@ -105,6 +106,7 @@ mtbl_res _mtbl_decompress_zlib	(const uint8_t *, const size_t, uint8_t **, size_
 /* metadata */
 
 struct mtbl_metadata {
+	mtbl_file_version	file_version;
 	uint64_t	index_block_offset;
 	uint64_t	data_block_size;
 	uint64_t	compression_algorithm;

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -241,6 +241,14 @@ mtbl_reader_options_set_verify_checksums(struct mtbl_reader_options *, bool);
 
 /* metadata */
 
+typedef enum {
+	MTBL_FORMAT_V1 = 0,
+	MTBL_FORMAT_V2 = 1
+} mtbl_file_version;
+
+mtbl_file_version
+mtbl_metadata_file_version(const struct mtbl_metadata *);
+
 uint64_t
 mtbl_metadata_index_block_offset(const struct mtbl_metadata *);
 

--- a/t/test-metadata.c
+++ b/t/test-metadata.c
@@ -8,6 +8,7 @@
 #include <mtbl.h>
 
 #include "metadata.c"
+#include "../libmy/b64_encode.c"
 
 #define NAME	"test-metadata"
 
@@ -27,6 +28,14 @@ test2(void)
 
 	return (ret);
 }
+
+#define TEST_ATTR(x, y, attr) \
+	do { \
+	if ((x).attr != (y).attr) { \
+		fprintf(stderr, NAME ": " #x "." #attr " != " #y "." #attr); \
+		ret |= 1; \
+	} \
+	} while (0);
 
 static int
 test1(void)
@@ -54,10 +63,16 @@ test1(void)
 		ret |= 1;
 	}
 
-	if (memcmp(&m1, &m2, sizeof(struct mtbl_metadata)) != 0) {
-		fprintf(stderr, NAME ": m1 != m2\n");
-		ret |= 1;
-	}
+	TEST_ATTR(m1, m2, file_version);
+	TEST_ATTR(m1, m2, index_block_offset);
+	TEST_ATTR(m1, m2, data_block_size);
+	TEST_ATTR(m1, m2, compression_algorithm);
+	TEST_ATTR(m1, m2, count_entries);
+	TEST_ATTR(m1, m2, count_data_blocks);
+	TEST_ATTR(m1, m2, bytes_data_blocks);
+	TEST_ATTR(m1, m2, bytes_index_block);
+	TEST_ATTR(m1, m2, bytes_keys);
+	TEST_ATTR(m1, m2, bytes_values);
 
 	return (ret);
 }

--- a/t/test-metadata.c
+++ b/t/test-metadata.c
@@ -37,6 +37,7 @@ test1(void)
 
 	memset(tbuf, 0, sizeof(tbuf));
 
+	m1.file_version = MTBL_FORMAT_V2;
 	m1.index_block_offset = 123;
 	m1.data_block_size = 65536;
 	m1.compression_algorithm = 1;


### PR DESCRIPTION
The original mtbl file format limited block sizes to what would fit in a
uint32. File format version 2 uses a varint64 instead. This commit makes
a library that is backwards compatible with version 1 but outputs
version 2 only.

**Versions of mtbl compiled before this commit will not be able to read mtbl files created with this and subsequent commits.**