### PR TITLE
configure.ac: work around liblz4's new naming convention

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,10 @@ else
     AC_MSG_ERROR([pkg-config is required!])
 fi
 
-PKG_CHECK_MODULES([liblz4], [liblz4 > 129])
+PKG_CHECK_MODULES([liblz4], [liblz4])
+AC_CHECK_LIB(lz4, LZ4_compress_HC, [], [
+    AC_MSG_ERROR([liblz4 >= r130 required])
+])
 
 AC_C_BIGENDIAN
 


### PR DESCRIPTION
they went from r131 to 1.7.3. We depended on r130 for the
LZ4_compress_HC function so we use AC_CHECK_LIB for it.