### PR TITLE
Fix t/test-metadata's _SOURCES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,7 +130,10 @@ t_test_fixed_LDADD = mtbl/libmtbl.la
 
 TESTS += t/test-metadata
 check_PROGRAMS += t/test-metadata
-t_test_metadata_SOURCES = t/test-metadata.c
+t_test_metadata_SOURCES = \
+	t/test-metadata.c \
+	libmy/b64_encode.c \
+	libmy/b64_encode.h
 t_test_metadata_LDADD = mtbl/libmtbl.la
 
 TESTS += t/test-varint

--- a/t/test-metadata.c
+++ b/t/test-metadata.c
@@ -7,8 +7,9 @@
 
 #include <mtbl.h>
 
+#include "libmy/b64_encode.h"
+
 #include "metadata.c"
-#include "../libmy/b64_encode.c"
 
 #define NAME	"test-metadata"
 


### PR DESCRIPTION
Add the `b64_encode.[ch]` dependency to t/test-metadata's `_SOURCES`, instead of trying to #include the C file.

This causes Automake to put the source files into the `make dist` source tarball.

This fixes #29.