### PR TITLE
Support large blocks

### DIFF
--- a/mtbl/block.c
+++ b/mtbl/block.c
@@ -51,16 +51,16 @@
 struct block {
 	uint8_t		*data;
 	size_t		size;
-	uint32_t	restart_offset;
+	uint64_t	restart_offset;
 	bool		needs_free;
 };
 
 struct block_iter {
 	struct block	*block;
 	uint8_t		*data;
-	uint32_t	restarts;
+	uint64_t	restarts;
 	uint32_t	num_restarts;
-	uint32_t	current;
+	uint64_t	current;
 	uint32_t	restart_index;
 	uint8_t		*next;
 	ubuf		*key;
@@ -152,14 +152,14 @@ block_iter_destroy(struct block_iter **bi)
 	}
 }
 
-static inline uint32_t
+static inline uint64_t
 next_entry_offset(struct block_iter *bi)
 {
 	/* return the offset in ->data just past the end of the current entry */
 	return (bi->next - bi->data);
 }
 
-static inline uint32_t
+static inline uint64_t
 get_restart_point(struct block_iter *bi, uint32_t idx)
 {
 	assert(idx < bi->num_restarts);
@@ -171,7 +171,7 @@ seek_to_restart_point(struct block_iter *bi, uint32_t idx)
 {
 	ubuf_reset(bi->key);
 	bi->restart_index = idx;
-	uint32_t offset = get_restart_point(bi, idx);
+	uint64_t offset = get_restart_point(bi, idx);
 	bi->next = bi->data + offset;
 }
 
@@ -238,7 +238,7 @@ block_iter_seek(struct block_iter *bi, const uint8_t *target, size_t target_len)
 	uint32_t right = bi->num_restarts - 1;
 	while (left < right) {
 		uint32_t mid = (left + right + 1) / 2;
-		uint32_t region_offset = get_restart_point(bi, mid);
+		uint64_t region_offset = get_restart_point(bi, mid);
 		uint32_t shared, non_shared, value_length;
 		const uint8_t *key_ptr = decode_entry(bi->data + region_offset,
 						      bi->data + bi->restarts,
@@ -286,7 +286,7 @@ void
 block_iter_prev(struct block_iter *bi)
 {
 	assert(block_iter_valid(bi));
-	const uint32_t original = bi->current;
+	const uint64_t original = bi->current;
 	while (get_restart_point(bi, bi->restart_index) >= original) {
 		if (bi->restart_index == 0) {
 			/* no more entries */

--- a/mtbl/block_builder.c
+++ b/mtbl/block_builder.c
@@ -87,14 +87,10 @@ block_builder_finish(struct block_builder *b, uint8_t **buf, size_t *bufsz)
 	ubuf_reserve(b->buf, uint32_vec_bytes(b->restarts) + sizeof(uint32_t));
 
 	for (size_t i = 0; i < uint32_vec_size(b->restarts); i++) {
-		//fprintf(stderr, "%s: writing restart value: %u\n", __func__,
-			//(unsigned) uint32_vec_value(b->restarts, i));
 		mtbl_fixed_encode32(ubuf_ptr(b->buf), uint32_vec_value(b->restarts, i));
 		ubuf_advance(b->buf, sizeof(uint32_t));
 	}
 
-	//fprintf(stderr, "%s: writing number of restarts: %u\n", __func__,
-		//(unsigned) uint32_vec_size(b->restarts));
 	mtbl_fixed_encode32(ubuf_ptr(b->buf), uint32_vec_size(b->restarts));
 	ubuf_advance(b->buf, sizeof(uint32_t));
 
@@ -126,7 +122,6 @@ block_builder_add(struct block_builder *b,
 			shared++;
 	} else {
 		/* restart compression */
-		//fprintf(stderr, "%s: doing restart\n", __func__);
 		uint32_vec_add(b->restarts, (uint32_t) ubuf_bytes(b->buf));
 		b->counter = 0;
 	}
@@ -136,21 +131,16 @@ block_builder_add(struct block_builder *b,
 	ubuf_reserve(b->buf, 5*3 + non_shared + len_val);
 
 	/* add "[shared][non-shared][value length]" to buffer */
-	//fprintf(stderr, "%s: writing value %u (shared)\n", __func__, (unsigned) shared);
 	ubuf_advance(b->buf, mtbl_varint_encode32(ubuf_ptr(b->buf), shared));
 
-	//fprintf(stderr, "%s: writing value %u (non-shared)\n", __func__, (unsigned) non_shared);
 	ubuf_advance(b->buf, mtbl_varint_encode32(ubuf_ptr(b->buf), non_shared));
 
-	//fprintf(stderr, "%s: writing value %u (value length)\n", __func__, (unsigned) len_val);
 	ubuf_advance(b->buf, mtbl_varint_encode32(ubuf_ptr(b->buf), len_val));
 
 	/* add key suffix to buffer followed by value */
-	//fprintf(stderr, "%s: writing %u bytes (key suffix)\n", __func__, (unsigned) non_shared);
 	memcpy(ubuf_ptr(b->buf), key + shared, non_shared);
 	ubuf_advance(b->buf, non_shared);
 
-	//fprintf(stderr, "%s: writing %u bytes (value)\n", __func__, (unsigned) len_val);
 	memcpy(ubuf_ptr(b->buf), val, len_val);
 	ubuf_advance(b->buf, len_val);
 


### PR DESCRIPTION
Use 64 bit restart offsets for blocks which contain more than 4GB of data, and continue to use 32 bit offsets for smaller blocks.

This change can operate within the existing file format, as it only changes the block format in the case of blocks with more than 4GB of data, which would not have been correctly written by the previous code.