### PR TITLE
Fix zlib default compression setting

### DIFF
--- a/mtbl/compression.c
+++ b/mtbl/compression.c
@@ -317,7 +317,7 @@ _mtbl_compress_zlib(
 		.zfree	= Z_NULL,
 	};
 
-	if (compression_level < Z_NO_COMPRESSION) {
+	if (compression_level < Z_DEFAULT_COMPRESSION) {
 		compression_level = Z_NO_COMPRESSION;
 	} else if (compression_level > Z_BEST_COMPRESSION) {
 		compression_level = Z_BEST_COMPRESSION;


### PR DESCRIPTION
zlib.h defines Z_DEFAULT_COMPRESSION to be less than Z_NO_COMPRESSION,
which was being rejected as an invalid value, turning off compression.