### PR TITLE
Add callback 'clos' parameter to mtbl_fileset_partition callback

### DIFF
--- a/man/mtbl_fileset.3
+++ b/man/mtbl_fileset.3
@@ -2,12 +2,12 @@
 .\"     Title: mtbl_fileset
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 02/17/2017
+.\"      Date: 05/09/2017
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_FILESET" "3" "02/17/2017" "\ \&" "\ \&"
+.TH "MTBL_FILESET" "3" "05/09/2017" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -64,6 +64,7 @@ mtbl_fileset_source(struct mtbl_fileset *\fR\fB\fIf\fR\fR\fB);\fR
 \fBvoid
 mtbl_fileset_partition(struct mtbl_fileset *\fR\fB\fIf\fR\fR\fB,
                 mtbl_filename_filter_func \fR\fB\fIcb\fR\fR\fB,
+                void *\fR\fB\fIclos\fR\fR\fB,
                 struct mtbl_merger **\fR\fB\fIm1\fR\fR\fB,
                 struct mtbl_merger **\fR\fB\fIm2\fR\fR\fB);\fR
 .fi

--- a/man/mtbl_fileset.3.txt
+++ b/man/mtbl_fileset.3.txt
@@ -34,6 +34,7 @@ mtbl_fileset_source(struct mtbl_fileset *'f');^
 ^void
 mtbl_fileset_partition(struct mtbl_fileset *'f',
 		mtbl_filename_filter_func 'cb',
+		void *'clos',
 		struct mtbl_merger \**'m1',
 		struct mtbl_merger **'m2');^
 

--- a/mtbl/fileset.c
+++ b/mtbl/fileset.c
@@ -231,6 +231,7 @@ mtbl_fileset_reload_now(struct mtbl_fileset *f)
 void
 mtbl_fileset_partition(struct mtbl_fileset *f,
 		mtbl_filename_filter_func cb,
+		void *clos,
 		struct mtbl_merger **m1,
 		struct mtbl_merger **m2)
 {
@@ -242,7 +243,7 @@ mtbl_fileset_partition(struct mtbl_fileset *f,
 	*m2 = mtbl_merger_init(f->mopt);
 
 	while (my_fileset_get(f->fs, i++, &fname, (void**) &reader)) {
-		if (cb(fname))
+		if (cb(fname, clos))
 			mtbl_merger_add_source(*m1, mtbl_reader_source(reader));
 		else
 			mtbl_merger_add_source(*m2, mtbl_reader_source(reader));

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -104,7 +104,7 @@ typedef void
 (*mtbl_merge_free_func)(void *clos);
 
 typedef bool
-(*mtbl_filename_filter_func)(const char *);
+(*mtbl_filename_filter_func)(const char *fname, void *clos);
 
 /* iter */
 
@@ -350,6 +350,7 @@ mtbl_fileset_source(struct mtbl_fileset *);
 void
 mtbl_fileset_partition(struct mtbl_fileset *,
 		mtbl_filename_filter_func,
+		void *,
 		struct mtbl_merger **,
 		struct mtbl_merger **);
 

--- a/t/test-fileset-partition.c
+++ b/t/test-fileset-partition.c
@@ -11,11 +11,12 @@
 char * fileset;
 
 static bool
-cb(const char *fn)
+cb(const char *fn, void *clos)
 {
+	const char *cn = (const char *)clos;
 	const char *bn;
 	bn = basename((char*)fn);
-	return strcmp(bn, "file1.mtbl") == 0;
+	return strcmp(bn, cn) == 0;
 }
 
 static void
@@ -43,7 +44,7 @@ test1(void)
 	mtbl_fileset_options_set_merge_func(opt, merge_func, NULL);
 	fs = mtbl_fileset_init(fileset, opt);
 
-	mtbl_fileset_partition(fs, cb, &m1, &m2);
+	mtbl_fileset_partition(fs, cb, "file1.mtbl", &m1, &m2);
 
 	s1 = mtbl_merger_source(m1);
 	s2 = mtbl_merger_source(m2);

--- a/t/test-fileset-partition.sh
+++ b/t/test-fileset-partition.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -z "${top_srcdir}" ]; then
     echo "top_srcdir variable not set"


### PR DESCRIPTION
Callers of mtbl_fileset_partition will likely need to pass parameters to callback. To support this, we modify the API to include a 'void *' closure parameter, akin to other C callback-based APIs.