### PR TITLE
Prepare release 1.1.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+mtbl (1.1.0)
+
+  * Fix default zlib compression level.
+  * Add callback data (clos) parameter to mtbl_fileset_partition
+    function and its callback. Early users of mtbl_fileset_partition
+    will need to rewrite accordingly.
+  * Use 64-bit offsets in blocks with more than 4G of data.
+
 mtbl (1.0.0)
 
  * Backwards-incompatible file format change to enable block sizes >4G.

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ mtbl (1.1.0)
     function and its callback. Early users of mtbl_fileset_partition
     will need to rewrite accordingly.
   * Use 64-bit offsets in blocks with more than 4G of data.
+  * Fix undefined behavior when seeking past end of mtbl file.
 
 mtbl (1.0.0)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ AM_LDFLAGS =
 ##
 #
 
-LIBMTBL_VERSION_INFO=1:0:0
+LIBMTBL_VERSION_INFO=1:1:0
 
 include_HEADERS = mtbl/mtbl.h
 lib_LTLIBRARIES = mtbl/libmtbl.la

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.64)
 AC_INIT([mtbl],
-        [1.0.0],
+        [1.1.0],
         [https://github.com/farsightsec/mtbl/issues],
         [mtbl],
         [https://github.com/farsightsec/mtbl])

--- a/mtbl/libmtbl.sym
+++ b/mtbl/libmtbl.sym
@@ -12,7 +12,6 @@ global:
         mtbl_fileset_options_init;
         mtbl_fileset_options_set_merge_func;
         mtbl_fileset_options_set_reload_interval;
-        mtbl_fileset_partition;
         mtbl_fileset_reload;
         mtbl_fileset_reload_now;
         mtbl_fileset_source;
@@ -86,3 +85,8 @@ global:
 local:
         *;
 };
+
+LIBMTBL_1.1.0 {
+global:
+        mtbl_fileset_partition;
+} LIBMTBL_1.0.0;

--- a/t/test-iter-seek.c
+++ b/t/test-iter-seek.c
@@ -153,6 +153,15 @@ test_iter(struct mtbl_iter *iter)
 
 		ubuf_destroy(&seek_key);
 	}
+
+	/* Attempt to seek past end of iterator */
+	ubuf *seek_key = ubuf_init(1);
+	const uint8_t *key, *value;
+	size_t len_key, len_value;
+
+	ubuf_add_fmt(seek_key, KEY_FMT, NUM_KEYS + 1);
+	assert(mtbl_iter_seek(iter, ubuf_data(seek_key), ubuf_size(seek_key)) == mtbl_res_success);
+	assert(mtbl_iter_next(iter, &key, &len_key, &value, &len_value) == mtbl_res_failure);
 }
 
 static void


### PR DESCRIPTION
Prepare for release.

Increment version of `mtbl_fileset_partition` symbol to reflect incompatible change to that API.