### PR TITLE
Fix mtbl_iter_seek() to a key beyond the end of an mtbl file.

### DIFF
--- a/mtbl/reader.c
+++ b/mtbl/reader.c
@@ -415,9 +415,12 @@ reader_iter_seek(void *v,
 
 	block_iter_seek(it->index_iter, key, len_key);
 
-	if (block_iter_get(it->index_iter, &ikey, &len_ikey, &ival, &len_ival)) {
-		mtbl_varint_decode64(ival, &new_offset);
+	if (!block_iter_get(it->index_iter, &ikey, &len_ikey, &ival, &len_ival)) {
+		it->valid = false;
+		return (mtbl_res_success);
 	}
+
+	mtbl_varint_decode64(ival, &new_offset);
 
 	/* We can skip decoding a new block if our new key is within the
 	 * currently-decoded block. */ 

--- a/mtbl/reader.c
+++ b/mtbl/reader.c
@@ -416,6 +416,10 @@ reader_iter_seek(void *v,
 	block_iter_seek(it->index_iter, key, len_key);
 
 	if (!block_iter_get(it->index_iter, &ikey, &len_ikey, &ival, &len_ival)) {
+		/* This seek puts us after the last key, so we mark the
+		 * iterator as invalid and return success. The next
+		 * mtbl_iter_next() operation will return mtbl_res_failure.
+		 */
 		it->valid = false;
 		return (mtbl_res_success);
 	}

--- a/t/test-iter-seek.c
+++ b/t/test-iter-seek.c
@@ -153,6 +153,15 @@ test_iter(struct mtbl_iter *iter)
 
 		ubuf_destroy(&seek_key);
 	}
+
+	/* Attempt to seek past end of iterator */
+	ubuf *seek_key = ubuf_init(1);
+	const uint8_t *key, *value;
+	size_t len_key, len_value;
+
+	ubuf_add_fmt(seek_key, KEY_FMT, NUM_KEYS + 1);
+	assert(mtbl_iter_seek(iter, ubuf_data(seek_key), ubuf_size(seek_key)) == mtbl_res_success);
+	assert(mtbl_iter_next(iter, &key, &len_key, &value, &len_value) == mtbl_res_failure);
 }
 
 static void


### PR DESCRIPTION
Fix undefined behavior when seeking past end of file iterator.