### PR TITLE
Fix for systems with 32bit size_t

### DIFF
--- a/mtbl/reader.c
+++ b/mtbl/reader.c
@@ -187,7 +187,9 @@ mtbl_reader_init_fd(int fd, const struct mtbl_reader_options *opt)
 		index_len_len = sizeof(uint32_t);
 		index_len = mtbl_fixed_decode32(r->data + r->m.index_block_offset + 0);
 	} else {
-		index_len_len = mtbl_varint_decode64(r->data + r->m.index_block_offset + 0, &index_len);
+		uint64_t tmp;
+		index_len_len = mtbl_varint_decode64(r->data + r->m.index_block_offset + 0, &tmp);
+		index_len = tmp;
 	}
 	index_crc = mtbl_fixed_decode32(r->data + r->m.index_block_offset + index_len_len);
 	index_data = r->data + r->m.index_block_offset + index_len_len + sizeof(uint32_t);
@@ -250,7 +252,9 @@ get_block(struct mtbl_reader *r, uint64_t offset)
 		raw_contents_size_len = sizeof(uint32_t);
 		raw_contents_size = mtbl_fixed_decode32(&r->data[offset + 0]);
 	} else {
-		raw_contents_size_len = mtbl_varint_decode64(&r->data[offset + 0], &raw_contents_size);
+		uint64_t tmp;
+		raw_contents_size_len = mtbl_varint_decode64(&r->data[offset + 0], &tmp);
+		raw_contents_size = tmp;
 	}
 	raw_contents = &r->data[offset + raw_contents_size_len + sizeof(uint32_t)];
 

--- a/src/mtbl_verify.c
+++ b/src/mtbl_verify.c
@@ -85,7 +85,9 @@ verify_data_blocks(
 			raw_contents_size = mtbl_fixed_decode32(&data[offset + 0]);
 			raw_contents_size_len = sizeof(uint32_t);
 		} else {
-			raw_contents_size_len = mtbl_varint_decode64(&data[offset + 0], &raw_contents_size);
+			uint64_t tmp;
+			raw_contents_size_len = mtbl_varint_decode64(&data[offset + 0], &tmp);
+			raw_contents_size = tmp;
 		}
 
 		/* Bounds check. */
@@ -93,7 +95,7 @@ verify_data_blocks(
 		bytes_consumed += raw_contents_size;
 		if (bytes_consumed > bytes_data_blocks) {
 			clear_line_stdout();
-			fprintf(stderr, "%s: Error: Block length (%'" PRIu64 " bytes) exceeds "
+			fprintf(stderr, "%s: Error: Block length (%'zu bytes) exceeds "
 				"total data length at "
 				"data block %" PRIu64 " (%" PRIu64 " bytes into file)\n",
 				prefix,


### PR DESCRIPTION
The file format introduced in release 1.0 supports up to 64-bit block sizes, but decoded the block size into a `size_t` variable passed by reference, leading to undefined behavior on platforms with `size_t` smaller than 64 bits. This patch fixes the assumption that `size_t` is 64 bits.