### PR TITLE
Handle 32bit size_t overflows.

### DIFF
--- a/mtbl/reader.c
+++ b/mtbl/reader.c
@@ -190,6 +190,10 @@ mtbl_reader_init_fd(int fd, const struct mtbl_reader_options *opt)
 		uint64_t tmp;
 		index_len_len = mtbl_varint_decode64(r->data + r->m.index_block_offset + 0, &tmp);
 		index_len = tmp;
+		if ((uint64_t)index_len != tmp) {
+			mtbl_reader_destroy(&r);
+			return NULL;
+		}
 	}
 	index_crc = mtbl_fixed_decode32(r->data + r->m.index_block_offset + index_len_len);
 	index_data = r->data + r->m.index_block_offset + index_len_len + sizeof(uint32_t);
@@ -255,6 +259,7 @@ get_block(struct mtbl_reader *r, uint64_t offset)
 		uint64_t tmp;
 		raw_contents_size_len = mtbl_varint_decode64(&r->data[offset + 0], &tmp);
 		raw_contents_size = tmp;
+		assert((uint64_t)raw_contents_size == tmp);
 	}
 	raw_contents = &r->data[offset + raw_contents_size_len + sizeof(uint32_t)];
 


### PR DESCRIPTION
When opening an mtbl_reader, handle an oversized index block as an
error. When opening an oversized data block, fail with an assertion
as mtbl does for other forms of corrupt blocks.