### PR TITLE
Print error message if mtbl_writer_init() fails to open a file.

### DIFF
--- a/mtbl/writer.c
+++ b/mtbl/writer.c
@@ -145,8 +145,11 @@ mtbl_writer_init(const char *fname, const struct mtbl_writer_options *opt)
 	int fd;
 
 	fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL, 0644);
-	if (fd < 0)
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open %s: %s", fname,
+			strerror(errno));
 		return (NULL);
+	}
 	w = mtbl_writer_init_fd(fd, opt);
 	close(fd);
 	return (w);


### PR DESCRIPTION
Add a useful error message to `mtbl_writer_init()` if it fails to open the supplied file.