### PR TITLE
Add lcov for coverage building.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends:
  debhelper (>= 9~),
  dh-autoreconf (>= 5~),
  dpkg-dev (>= 1.16.0~),
+ lcov,
  liblz4-dev (>= 0.0~r130),
  libsnappy-dev,
  libzstd-dev,


### PR DESCRIPTION
In concert with #52 , this adds lcov to `debian/control`.