### PR TITLE
Add libmy coverage, following fstrm example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *~
 .*swp
+*.gcda
+*.gcno
 *.la
 *.lo
 *.log
@@ -14,6 +16,8 @@
 /build-aux
 /config.*
 /configure
+/coverage.info
+/coveragereport
 /libtool
 /stamp-h1
 Makefile

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,18 @@ AM_LDFLAGS =
 
 #
 ##
+### code coverage
+##
+#
+
+AM_CFLAGS += ${CODE_COVERAGE_CFLAGS}
+AM_LDFLAGS += ${CODE_COVERAGE_LDFLAGS}
+CODE_COVERAGE_LCOV_OPTIONS = --no-external
+CODE_COVERAGE_IGNORE_PATTERN = "$(abs_top_builddir)/t/*"
+@CODE_COVERAGE_RULES@
+
+#
+##
 ### library
 ##
 #

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,9 @@ fi
 
 gl_LD_VERSION_SCRIPT
 
+m4_include([libmy/m4/my_code_coverage.m4])
+MY_CODE_COVERAGE
+
 AC_OUTPUT
 AC_MSG_RESULT([
     $PACKAGE $VERSION
@@ -102,4 +105,5 @@ AC_MSG_RESULT([
         bigendian:              ${ac_cv_c_bigendian}
 
         building manpage docs:  ${DOC_MAN_MSG}
+        code coverage enabled:  ${CODE_COVERAGE_ENABLED}
 ])


### PR DESCRIPTION
This uses the libmy code coverage macro, following the example in fstrm. To enable, use `--enable-code-coverage` during configure, then `make check-code-coverage`. Note that we newly require the installation of lcov --a separate PR for our debian branch exists in #51 .