### PR TITLE
Make index block checksum verification optional

### DIFF
--- a/man/mtbl_reader.3
+++ b/man/mtbl_reader.3
@@ -2,12 +2,12 @@
 .\"     Title: mtbl_reader
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 11/10/2022
+.\"      Date: 11/14/2022
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_READER" "3" "11/10/2022" "\ \&" "\ \&"
+.TH "MTBL_READER" "3" "11/14/2022" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -104,7 +104,7 @@ File\-level metadata may be accessed using the \fBmtbl_metadata\fR(3) interface,
 \fBverify_checksums\fR
 .RS 4
 .sp
-Specifies whether or not the CRC32C checksum on the index block and each data block should be verified or not\&. If \fIverify_checksums\fR is enabled, a checksum mismatch will cause a runtime error\&. The default is to not verify index or data block checksums\&.
+Specifies whether or not the CRC32C checksum on the index block and each data block should be verified or not\&. If \fIverify_checksums\fR is enabled, a checksum mismatch will cause a fatal runtime error\&. The default is to not verify index or data block checksums\&.
 .RE
 .sp
 .it 1 an-trap

--- a/man/mtbl_reader.3
+++ b/man/mtbl_reader.3
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mtbl_reader
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 02/03/2015
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 11/10/2022
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_READER" "3" "02/03/2015" "\ \&" "\ \&"
+.TH "MTBL_READER" "3" "11/10/2022" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -104,7 +104,7 @@ File\-level metadata may be accessed using the \fBmtbl_metadata\fR(3) interface,
 \fBverify_checksums\fR
 .RS 4
 .sp
-Specifies whether or not the CRC32C checksum on each data block should be verified or not\&. If \fIverify_checksums\fR is enabled, a checksum mismatch will cause a runtime error\&. Note that the checksum on the index block is always verified, since the overhead of doing this once when the reader object is instantiated is minimal\&. The default is to not verify data block checksums\&.
+Specifies whether or not the CRC32C checksum on the index block and each data block should be verified or not\&. If \fIverify_checksums\fR is enabled, a checksum mismatch will cause a runtime error\&. The default is to not verify index or data block checksums\&.
 .RE
 .sp
 .it 1 an-trap

--- a/man/mtbl_reader.3.txt
+++ b/man/mtbl_reader.3.txt
@@ -76,11 +76,10 @@ metadata object is valid only as long as the reader object exists.
 
 ==== verify_checksums ====
 
-Specifies whether or not the CRC32C checksum on each data block should be
-verified or not. If _verify_checksums_ is enabled, a checksum mismatch will
-cause a runtime error. Note that the checksum on the index block is always
-verified, since the overhead of doing this once when the reader object is
-instantiated is minimal. The default is to not verify data block checksums.
+Specifies whether or not the CRC32C checksum on the index block and each
+data block should be verified or not. If _verify_checksums_ is enabled, a
+checksum mismatch will cause a runtime error. The default is to not verify
+index or data block checksums.
 
 ==== madvise_random ====
 

--- a/man/mtbl_reader.3.txt
+++ b/man/mtbl_reader.3.txt
@@ -78,7 +78,7 @@ metadata object is valid only as long as the reader object exists.
 
 Specifies whether or not the CRC32C checksum on the index block and each
 data block should be verified or not. If _verify_checksums_ is enabled, a
-checksum mismatch will cause a runtime error. The default is to not verify
+checksum mismatch will cause a fatal runtime error. The default is to not verify
 index or data block checksums.
 
 ==== madvise_random ====

--- a/src/mtbl_verify.c
+++ b/src/mtbl_verify.c
@@ -165,6 +165,7 @@ verify_file(const char *fname)
 	bool res = true;
 	int fd;
 	struct mtbl_reader *r;
+	struct mtbl_reader_options *ropt;
 	const struct mtbl_metadata *m;
 
 	fd = open(fname, O_RDONLY);
@@ -173,7 +174,10 @@ verify_file(const char *fname)
 		return false;
 	}
 
-	r = mtbl_reader_init_fd(fd, NULL);
+	ropt = mtbl_reader_options_init();
+	mtbl_reader_options_set_verify_checksums(ropt, true);
+	r = mtbl_reader_init_fd(fd, ropt);
+	mtbl_reader_options_destroy(&ropt);
 	if (r == NULL) {
 		close(fd);
 		fprintf(stderr, "%s: mtbl_reader_init_fd() failed\n", fname);


### PR DESCRIPTION
Verify the index block checksum only if checksum verification of index and data blocks is requested. Request this option in mtbl_verify utility rather than relying on default check of index block.