### PR TITLE
Release 1.5.1

### DIFF
--- a/libmy/heap.c
+++ b/libmy/heap.c
@@ -59,7 +59,7 @@ void heap_clip(struct heap *h, size_t n_elems)
 }
 
 static void
-siftdown(struct heap *h)
+siftup(struct heap *h)
 {
 	size_t pos = ptrvec_size(h->vec)-1;
 	void *newitem = ptrvec_value(h->vec, pos);
@@ -75,7 +75,7 @@ siftdown(struct heap *h)
 }
 
 static void
-siftup(struct heap *h, size_t pos)
+siftdown(struct heap *h, size_t pos)
 {
 	assert(pos < ptrvec_size(h->vec));
 	void *newitem = ptrvec_value(h->vec, pos);
@@ -105,7 +105,7 @@ void
 heap_heapify(struct heap *h)
 {
 	for (size_t i = ptrvec_size(h->vec)/2; i-- > 0; ) {
-		siftup(h, i);
+		siftdown(h, i);
 	}
 }
 
@@ -119,7 +119,7 @@ void
 heap_push(struct heap *h, void *item)
 {
 	ptrvec_add(h->vec, item);
-	siftdown(h);
+	siftup(h);
 }
 
 void *
@@ -133,7 +133,7 @@ heap_pop(struct heap *h)
 	if (ptrvec_size(h->vec) > 0) {
 		returnitem = ptrvec_value(h->vec, 0);
 		ptrvec_data(h->vec)[0] = lastelt;
-		siftup(h, 0);
+		siftdown(h, 0);
 	} else {
 		returnitem = lastelt;
 	}
@@ -147,7 +147,7 @@ heap_replace(struct heap *h, void *item)
 		return (NULL);
 	void *returnitem = ptrvec_value(h->vec, 0);
 	ptrvec_data(h->vec)[0] = item;
-	siftup(h, 0);
+	siftdown(h, 0);
 	return (returnitem);
 }
 

--- a/t/test-iter-seek.c
+++ b/t/test-iter-seek.c
@@ -12,6 +12,7 @@
 #define NAME		"test-iter-seek"
 
 #define NUM_KEYS	128
+#define NUM_FILES	8
 #define RESTART_INTERVAL	4
 
 #define KEY_FMT		"%08x"
@@ -37,17 +38,18 @@ my_merge_func(void *clos,
         uint8_t **merged_val, size_t *len_merged_val);
 
 static int
-test1(FILE *tmp, FILE *tmp2) {
+test1(FILE *tmps[NUM_FILES]) {
+	int i;
+	struct mtbl_reader *readers[NUM_FILES];
 	struct mtbl_reader_options *reader_options = mtbl_reader_options_init();
 	assert(reader_options != NULL);
 
-	struct mtbl_reader *reader = mtbl_reader_init_fd(dup(fileno(tmp)), reader_options);
-	assert(reader != NULL);
+	for (i = 0; i < NUM_FILES; i++) {
+		readers[i] = mtbl_reader_init_fd(dup(fileno(tmps[i])), reader_options);
+		assert(readers[i] != NULL);
+	}
 
-	const struct mtbl_source *source = mtbl_reader_source(reader);
-	assert(source != NULL);
-
-	struct mtbl_iter *iter = mtbl_source_iter(source);
+	struct mtbl_iter *iter = mtbl_source_iter(mtbl_reader_source(readers[0]));
 	assert(iter != NULL);
 
 	if (test_iter(iter) != 0) {
@@ -65,7 +67,7 @@ test1(FILE *tmp, FILE *tmp2) {
 	struct mtbl_merger *merger = mtbl_merger_init(merger_options);
 	assert(merger != NULL);
 
-	mtbl_merger_add_source(merger, source);
+	mtbl_merger_add_source(merger, mtbl_reader_source(readers[0]));
 
 	const struct mtbl_source *merger_source = mtbl_merger_source(merger);
 	assert(merger_source != NULL);
@@ -80,10 +82,8 @@ test1(FILE *tmp, FILE *tmp2) {
 
 	mtbl_iter_destroy(&merger_iter);
 
-	struct mtbl_reader *reader2 = mtbl_reader_init_fd(dup(fileno(tmp2)), reader_options);
-	assert(reader2 != NULL);
-
-	mtbl_merger_add_source(merger, mtbl_reader_source(reader2));
+	for (i = 1; i < NUM_FILES; i++)
+		mtbl_merger_add_source(merger, mtbl_reader_source(readers[i]));
 
 	merger_iter = mtbl_source_iter(merger_source);
 	assert(merger_iter != NULL);
@@ -95,10 +95,12 @@ test1(FILE *tmp, FILE *tmp2) {
 
 	mtbl_iter_destroy(&merger_iter);
 
+	for (i = 0; i < NUM_FILES; i++) {
+		mtbl_reader_destroy(&readers[i]);
+	}
+
 	mtbl_merger_destroy(&merger);
 	mtbl_merger_options_destroy(&merger_options);
-	mtbl_reader_destroy(&reader);
-	mtbl_reader_destroy(&reader2);
 	mtbl_reader_options_destroy(&reader_options);
 	return 0;
 }
@@ -193,20 +195,20 @@ check(int ret, const char *s)
 }
 
 int main(int argc, char ** argv) {
-	int ret = 0;
-	FILE *tmp = tmpfile();
-	assert(tmp != NULL);
-	init_mtbl(dup(fileno(tmp)), NUM_KEYS, 1024, 
-		DEFAULT_BLOCK_RESTART_INTERVAL);
-	
-	FILE *tmp2 = tmpfile();
-	assert(tmp2 != NULL);
-	init_mtbl(dup(fileno(tmp2)), NUM_KEYS, 1024, 
-		DEFAULT_BLOCK_RESTART_INTERVAL);
+	int i, ret = 0;
+	FILE *tmps[NUM_FILES];
 
-	ret |= check(test1(tmp, tmp2), "test 1");
-	fclose(tmp);
-	fclose(tmp2);
+	for (i = 0; i < NUM_FILES; i++) {
+		tmps[i] = tmpfile();
+		init_mtbl(dup(fileno(tmps[i])), NUM_KEYS, 1024,
+				DEFAULT_BLOCK_RESTART_INTERVAL);
+	}
+
+	ret |= check(test1(tmps), "test 1");
+
+	for (i = 0; i < NUM_FILES; i++) {
+		fclose(tmps[i]);
+	}
 
 	/* Make a larger tmp mtbl so we have larger restart arrays */
 	int32_t test_2_num_keys = NUM_KEYS * 100;
@@ -219,7 +221,7 @@ int main(int argc, char ** argv) {
 	/* From each key, test seeking from 0 to RESTART_INTERVAL keys
 	 * forward and backward */
 	char test2_label[TEST2_LABEL_LEN];
-	for (uint8_t i = 0; i < RESTART_INTERVAL; i++) {
+	for (i = 0; i < RESTART_INTERVAL; i++) {
 		snprintf(test2_label, TEST2_LABEL_LEN, TEST2_LABEL_FMT,
 			RESTART_INTERVAL - i);
 		ret |= check(test2(tmp3, test_2_num_keys, RESTART_INTERVAL - i),
@@ -301,7 +303,7 @@ test_iter(struct mtbl_iter *iter)
 		if (mtbl_iter_next(iter, &key, &len_key, &value, &len_value) != mtbl_res_success) {
 			return 1;
 		}
-		
+
 		if (bytes_compare(ubuf_data(expected_key), ubuf_size(expected_key), key, len_key) != 0) {
 			return 1;
 		}
@@ -319,6 +321,17 @@ test_iter(struct mtbl_iter *iter)
 		}
 	}
 
+	/* Loop forward from 0 and seek i + jump keys */
+	int jump = NUM_KEYS/8;
+	for (int32_t i = 0; i < NUM_KEYS; i += jump) {
+		if ((i + 4) < jump) {
+			int32_t target_number = i + jump;
+			if (seek_and_check(iter, i, target_number) != 0) {
+				return 1;
+			};
+		}
+	}
+
 	/* Seek to a key, ensure that we get the one we want and that we go
 	 * all the way to the end. */
 	for (uint32_t i = NUM_KEYS; i-- > 0; ) {
@@ -331,7 +344,7 @@ test_iter(struct mtbl_iter *iter)
 		if (mtbl_iter_seek(iter, ubuf_data(seek_key), ubuf_size(seek_key)) != mtbl_res_success) {
 			return 1;
 		}
-		
+
 		for (uint32_t j = i; j < NUM_KEYS; j++) {
 			ubuf *expected_key = ubuf_init(1);
 			ubuf_add_fmt(expected_key, KEY_FMT, j);
@@ -339,7 +352,7 @@ test_iter(struct mtbl_iter *iter)
 			if (mtbl_iter_next(iter, &key, &len_key, &value, &len_value) != mtbl_res_success) {
 				return 1;
 			}
-			
+
 			if (bytes_compare(ubuf_data(expected_key), ubuf_size(expected_key), key, len_key) != 0) {
 				return 1;
 			}


### PR DESCRIPTION
This release includes two improvements to the mtbl_merger code:
  * Skip unnecessary seeks when seeking forward on a merger iterator
  * Fix inefficiency in heap implementation impacting merger iterator performance