### PR TITLE
Next dvladi perf

### DIFF
--- a/mtbl/varint.c
+++ b/mtbl/varint.c
@@ -133,14 +133,13 @@ mtbl_varint_encode64(uint8_t *src_ptr, uint64_t v)
 size_t
 mtbl_varint_decode32(const uint8_t *data, uint32_t *value)
 {
-	size_t len = 0;
-	uint32_t val = data[len] & 0x7f;
-	size_t ndx = 7;
+	size_t len = 0, shift = 0 ;
+	uint64_t val = 0;
 
-	while(data[len++] & 0x80 && ndx < 29) {
-		val |= ((data[len] & 0x7f) << ndx);
-		ndx += 7;
-	}
+	do {
+		val |= (((uint64_t)(data[len] & 0x7f)) << shift);
+		shift += 7;
+	} while ((data[len++] & 0x80) != 0 && shift < 32);
 
 	*value = val;
 	return len;
@@ -149,14 +148,13 @@ mtbl_varint_decode32(const uint8_t *data, uint32_t *value)
 size_t
 mtbl_varint_decode64(const uint8_t *data, uint64_t *value)
 {
-	size_t len = 0;
-	uint64_t val = data[len] & 0x7f;
-	size_t ndx = 7;
+	size_t len = 0, shift = 0 ;
+	uint64_t val = 0;
 
-	while(data[len++] & 0x80 && ndx < 64) {
-		val |= (((uint64_t)(data[len] & 0x7f)) << ndx);
-		ndx += 7;
-	}
+	do {
+		val |= (((uint64_t)(data[len] & 0x7f)) << shift);
+		shift += 7;
+	} while ((data[len++] & 0x80) != 0 && shift < 64);
 
 	*value = val;
 	return len;

--- a/mtbl/varint.c
+++ b/mtbl/varint.c
@@ -135,18 +135,11 @@ mtbl_varint_decode32(const uint8_t *data, uint32_t *value)
 {
 	size_t len = 0;
 	uint32_t val = data[len] & 0x7f;
+	size_t ndx = 7;
 
-	if (data[len++] & 0x80) {
-		val |= ((data[len] & 0x7f) << 7);
-		if (data[len++] & 0x80) {
-			val |= ((data[len] & 0x7f) << 14);
-			if (data[len++] & 0x80) {
-				val |= ((data[len] & 0x7f) << 21);
-				if (data[len++] & 0x80) {
-					val |= ((data[len++] & 0x7f) << 28);
-				}
-			}
-		}
+	while(data[len++] & 0x80 && ndx < 29) {
+		val |= ((data[len] & 0x7f) << ndx);
+		ndx += 7;
 	}
 
 	*value = val;
@@ -158,33 +151,11 @@ mtbl_varint_decode64(const uint8_t *data, uint64_t *value)
 {
 	size_t len = 0;
 	uint64_t val = data[len] & 0x7f;
+	size_t ndx = 7;
 
-	if (data[len++] & 0x80) {
-		val |= (((uint64_t)(data[len] & 0x7f)) << 7);
-		if (data[len++] & 0x80) {
-			val |= (((uint64_t)(data[len] & 0x7f)) << 14);
-			if (data[len++] & 0x80) {
-				val |= (((uint64_t)(data[len] & 0x7f)) << 21);
-				if (data[len++] & 0x80) {
-					val |= (((uint64_t)(data[len] & 0x7f)) << 28);
-					if (data[len++] & 0x80) {
-						val |= (((uint64_t)(data[len] & 0x7f)) << 35);
-						if (data[len++] & 0x80) {
-							val |= (((uint64_t)(data[len] & 0x7f)) << 42);
-							if (data[len++] & 0x80) {
-								val |= (((uint64_t)(data[len] & 0x7f)) << 49);
-								if (data[len++] & 0x80) {
-									val |= (((uint64_t)(data[len] & 0x7f)) << 56);
-									if (data[len++] & 0x80) {
-										val |= (((uint64_t)(data[len++] & 0x7f)) << 63);
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+	while(data[len++] & 0x80 && ndx < 64) {
+		val |= (((uint64_t)(data[len] & 0x7f)) << ndx);
+		ndx += 7;
 	}
 
 	*value = val;

--- a/mtbl/varint.c
+++ b/mtbl/varint.c
@@ -133,45 +133,60 @@ mtbl_varint_encode64(uint8_t *src_ptr, uint64_t v)
 size_t
 mtbl_varint_decode32(const uint8_t *data, uint32_t *value)
 {
-	unsigned len = mtbl_varint_length_packed(data, 5);
-	uint32_t val = data[0] & 0x7f;
-	if (len > 1) {
-		val |= ((data[1] & 0x7f) << 7);
-		if (len > 2) {
-			val |= ((data[2] & 0x7f) << 14);
-			if (len > 3) {
-				val |= ((data[3] & 0x7f) << 21);
-				if (len > 4)
-					val |= (data[4] << 28);
+	size_t len = 0;
+	uint32_t val = data[len] & 0x7f;
+
+	if (data[len++] & 0x80) {
+		val |= ((data[len] & 0x7f) << 7);
+		if (data[len++] & 0x80) {
+			val |= ((data[len] & 0x7f) << 14);
+			if (data[len++] & 0x80) {
+				val |= ((data[len] & 0x7f) << 21);
+				if (data[len++] & 0x80) {
+					val |= ((data[len++] & 0x7f) << 28);
+				}
 			}
 		}
 	}
+
 	*value = val;
-	return ((size_t) len);
+	return len;
 }
 
 size_t
 mtbl_varint_decode64(const uint8_t *data, uint64_t *value)
 {
-	unsigned shift, i;
-	unsigned len = mtbl_varint_length_packed(data, 10);
-	uint64_t val;
-	if (len < 5) {
-		size_t tmp_len;
-		uint32_t tmp;
-		tmp_len = mtbl_varint_decode32(data, &tmp);
-		*value = tmp;
-		return (tmp_len);
+	size_t len = 0;
+	uint64_t val = data[len] & 0x7f;
+
+	if (data[len++] & 0x80) {
+		val |= (((uint64_t)(data[len] & 0x7f)) << 7);
+		if (data[len++] & 0x80) {
+			val |= (((uint64_t)(data[len] & 0x7f)) << 14);
+			if (data[len++] & 0x80) {
+				val |= (((uint64_t)(data[len] & 0x7f)) << 21);
+				if (data[len++] & 0x80) {
+					val |= (((uint64_t)(data[len] & 0x7f)) << 28);
+					if (data[len++] & 0x80) {
+						val |= (((uint64_t)(data[len] & 0x7f)) << 35);
+						if (data[len++] & 0x80) {
+							val |= (((uint64_t)(data[len] & 0x7f)) << 42);
+							if (data[len++] & 0x80) {
+								val |= (((uint64_t)(data[len] & 0x7f)) << 49);
+								if (data[len++] & 0x80) {
+									val |= (((uint64_t)(data[len] & 0x7f)) << 56);
+									if (data[len++] & 0x80) {
+										val |= (((uint64_t)(data[len++] & 0x7f)) << 63);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 	}
-	val = ((data[0] & 0x7f))
-		| ((data[1] & 0x7f) << 7)
-		| ((data[2] & 0x7f) << 14)
-		| ((data[3] & 0x7f) << 21);
-	shift = 28;
-	for (i = 4; i < len; i++) {
-		val |= (((uint64_t)(data[i] & 0x7f)) << shift);
-		shift += 7;
-	}
+
 	*value = val;
-	return ((size_t) len);
+	return len;
 }

--- a/t/test-varint.c
+++ b/t/test-varint.c
@@ -8,6 +8,62 @@
 
 #define NAME	"test-varint"
 
+
+/* Test invalid varint encoding. */
+static int
+test4(void)
+{
+	uint64_t val_64;
+	uint32_t val_32;
+	size_t len;
+	int ret = 0;
+
+	/*
+	 * A varint will continue to decode so long as the present byte has the
+	 * 0x80 bit set, or until the maximum encoded length has been reached.
+	 * For a 32bit varint, the max len is 5 bytes, and the 5th byte MUST
+	 * be <= 0x80 in value, or decoding will fail.
+	 */
+	static uint8_t bad_varint_1[5] = "\xab\xc1\x91\x98\x7f";
+
+	len = mtbl_varint_decode32(bad_varint_1, &val_32);
+	if (len != 5 || val_32 != 4077150379)
+		return 1;
+
+	bad_varint_1[4]++;	/* Corrupt the last byte to be >= 0x80 */
+	len = mtbl_varint_decode32(bad_varint_1, &val_32);
+	if (len != 0 || val_32 != 0)
+		return 1;
+
+	/* Set the second to last byte to zero and the length decreases. */
+	bad_varint_1[3] = 0;
+	len = mtbl_varint_decode32(bad_varint_1, &val_32);
+	if (len != 4)
+		return 1;
+
+	/*
+	 * We do essentially the same thing with a 64bit varint, except here the
+	 * maximum encoded length is 10 bytes rather than 5.
+	 */
+	static uint8_t bad_varint_2[10] = "\xff\xc1\x91\x98\x81\xff\xe3\x98\x87\x7f";
+
+	len = mtbl_varint_decode64(bad_varint_2, &val_64);
+	if (len != 10 || val_64 != 9741725764612808959UL)
+		return 1;
+
+	bad_varint_2[9]++;	/* corrupt the last byte to be >= 0x80 */
+	len = mtbl_varint_decode64(bad_varint_2, &val_64);
+	if (len != 0 || val_64 != 0)
+		return 1;
+
+	bad_varint_2[8] = 0;	/* truncate the decoding at 2nd to last byte */
+	len = mtbl_varint_decode64(bad_varint_2, &val_64);
+	if (len != 9)
+		return 1;
+
+	return ret;
+}
+
 static int
 test3(void)
 {
@@ -167,6 +223,7 @@ main(int argc, char **argv)
 	ret |= check(test1(), "test1");
 	ret |= check(test2(), "test2");
 	ret |= check(test3(), "test3");
+	ret |= check(test4(), "test3");
 
 	if (ret)
 		return (EXIT_FAILURE);


### PR DESCRIPTION
Improve performance of mtbl_varint_decode32 and mtbl_varint_decode64 by calculating field length instead of calling mtbl_varint_length_packed

mtbl_varint_decode32 performance improved 25% 
Original: 0.19% overall time spent in 616886 calls
Modified: 0.14% overall time spent in 616886 calls

mtbl_varint_decode64 performance improved 25%
Original: 1.94% overall time spent in 616886 calls
Modified: 1.42% overall time spent in 616886 calls
