### PR TITLE
Further mtbl_iter_seek optimizations

### DIFF
--- a/mtbl/merger.c
+++ b/mtbl/merger.c
@@ -190,6 +190,7 @@ merger_iter_seek(void *v, const uint8_t *key, size_t len_key)
 {
 	struct merger_iter *it = (struct merger_iter *) v;
 	struct entry *e;
+	bool changed = false;
 	mtbl_res res;
 
 	it->finished = false;
@@ -202,7 +203,8 @@ merger_iter_seek(void *v, const uint8_t *key, size_t len_key)
 	 * the iterator (e == NULL), seek all entries to the desired key
 	 * and rebuild the heap.
 	 */
-	if (e == NULL || bytes_compare(key, len_key, e->key, e->len_key) < 0) {
+	if (e == NULL || ubuf_size(it->cur_key) == 0 ||
+	    bytes_compare(key, len_key, ubuf_data(it->cur_key), ubuf_size(it->cur_key)) < 0) {
 		heap_clip(it->h, 0);
 		for (size_t i = 0; i < entry_vec_size(it->entries); i++) {
 			struct entry *ent = entry_vec_value(it->entries, i);
@@ -223,6 +225,7 @@ merger_iter_seek(void *v, const uint8_t *key, size_t len_key)
 	 * need to seek those entries which are behind the desired key.
 	 */
 	while (bytes_compare(key, len_key, e->key, e->len_key) > 0) {
+		changed = true;
 		res = mtbl_iter_seek(e->it, key, len_key);
 		if (res == mtbl_res_success && entry_fill(e) == mtbl_res_success) {
 			heap_replace(it->h, e);
@@ -235,6 +238,16 @@ merger_iter_seek(void *v, const uint8_t *key, size_t len_key)
 				break;
 			}
 		}
+	}
+
+	/*
+	 * If the seek operation changed the internal state of the iterator,
+	 * record the seek key for the purposes of detecting a backward seek.
+	 */
+	if (changed) {
+		ubuf_clip(it->cur_val, 0);
+		ubuf_clip(it->cur_key, 0);
+		ubuf_append(it->cur_key, key, len_key);
 	}
 
 	return (mtbl_res_success);


### PR DESCRIPTION
Further optimize short forward `mtbl_iter_seek` operations.

1. At the block level, start from current key when seeking forward within a restart interval, avoiding unnecessary scans.
2. At the reader level, avoid index seeks when seeking forward within the same data block.
3. At the merger level, treat a seek between the previous key and next key as a no-op.