### PR TITLE
Return mtbl_iter_init to public header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.64)
 AC_INIT([mtbl],
-        [1.5.1],
+        [1.6.0],
         [https://github.com/farsightsec/mtbl/issues],
         [mtbl],
         [https://github.com/farsightsec/mtbl])

--- a/mtbl/mtbl-private.h
+++ b/mtbl/mtbl-private.h
@@ -106,11 +106,6 @@ mtbl_res _mtbl_decompress_snappy(const uint8_t *, const size_t, uint8_t **, size
 mtbl_res _mtbl_decompress_zlib	(const uint8_t *, const size_t, uint8_t **, size_t *);
 mtbl_res _mtbl_decompress_zstd	(const uint8_t *, const size_t, uint8_t **, size_t *);
 
-/* iter */
-
-struct mtbl_iter *
-mtbl_iter_init(mtbl_iter_seek_func, mtbl_iter_next_func, mtbl_iter_free_func, void *clos);
-
 /* metadata */
 
 struct mtbl_metadata {

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -134,6 +134,13 @@ typedef mtbl_res
 typedef void
 (*mtbl_iter_free_func)(void *);
 
+struct mtbl_iter *
+mtbl_iter_init(
+	mtbl_iter_seek_func,
+	mtbl_iter_next_func,
+	mtbl_iter_free_func,
+	void *clos);
+
 void
 mtbl_iter_destroy(struct mtbl_iter **);
 


### PR DESCRIPTION
`mtbl_iter_init` was partly removed from the public API prior to the 1.0 release when adding the `mtbl_iter_seek` operation changed its function signature.  Since there has been at least one major API and ABI revision since this removal, it can safely be re-added as if it is a new API function.