### PR TITLE
mtbl 1.6.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ mtbl_libmtbl_la_SOURCES = \
 
 mtbl_libmtbl_la_LIBADD = -lsnappy -lz $(liblz4_LIBS) $(libzstd_LIBS)
 mtbl_libmtbl_la_LDFLAGS = $(AM_LDFLAGS) \
+	-no-undefined \
 	-version-info $(LIBMTBL_VERSION_INFO)
 if HAVE_LD_VERSION_SCRIPT
 mtbl_libmtbl_la_LDFLAGS += \

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.64)
 AC_INIT([mtbl],
-        [1.5.1],
+        [1.6.0],
         [https://github.com/farsightsec/mtbl/issues],
         [mtbl],
         [https://github.com/farsightsec/mtbl])

--- a/mtbl/compression.c
+++ b/mtbl/compression.c
@@ -393,8 +393,8 @@ _mtbl_decompress_zstd(
 	if (input_size > INT_MAX)
 		return (mtbl_res_failure);
 
-	*output_size = (size_t) ZSTD_getDecompressedSize(input, input_size);
-	if (*output_size == 0)
+	*output_size = (size_t) ZSTD_getFrameContentSize(input, input_size);
+	if (*output_size <= 0)
 		return (mtbl_res_failure);
 
 	*output = my_malloc(*output_size);

--- a/mtbl/merger.c
+++ b/mtbl/merger.c
@@ -190,6 +190,7 @@ merger_iter_seek(void *v, const uint8_t *key, size_t len_key)
 {
 	struct merger_iter *it = (struct merger_iter *) v;
 	struct entry *e;
+	bool changed = false;
 	mtbl_res res;
 
 	it->finished = false;
@@ -202,7 +203,8 @@ merger_iter_seek(void *v, const uint8_t *key, size_t len_key)
 	 * the iterator (e == NULL), seek all entries to the desired key
 	 * and rebuild the heap.
 	 */
-	if (e == NULL || bytes_compare(key, len_key, e->key, e->len_key) < 0) {
+	if (e == NULL || ubuf_size(it->cur_key) == 0 ||
+	    bytes_compare(key, len_key, ubuf_data(it->cur_key), ubuf_size(it->cur_key)) < 0) {
 		heap_clip(it->h, 0);
 		for (size_t i = 0; i < entry_vec_size(it->entries); i++) {
 			struct entry *ent = entry_vec_value(it->entries, i);
@@ -223,6 +225,7 @@ merger_iter_seek(void *v, const uint8_t *key, size_t len_key)
 	 * need to seek those entries which are behind the desired key.
 	 */
 	while (bytes_compare(key, len_key, e->key, e->len_key) > 0) {
+		changed = true;
 		res = mtbl_iter_seek(e->it, key, len_key);
 		if (res == mtbl_res_success && entry_fill(e) == mtbl_res_success) {
 			heap_replace(it->h, e);
@@ -235,6 +238,16 @@ merger_iter_seek(void *v, const uint8_t *key, size_t len_key)
 				break;
 			}
 		}
+	}
+
+	/*
+	 * If the seek operation changed the internal state of the iterator,
+	 * record the seek key for the purposes of detecting a backward seek.
+	 */
+	if (changed) {
+		ubuf_clip(it->cur_val, 0);
+		ubuf_clip(it->cur_key, 0);
+		ubuf_append(it->cur_key, key, len_key);
 	}
 
 	return (mtbl_res_success);

--- a/mtbl/mtbl-private.h
+++ b/mtbl/mtbl-private.h
@@ -106,11 +106,6 @@ mtbl_res _mtbl_decompress_snappy(const uint8_t *, const size_t, uint8_t **, size
 mtbl_res _mtbl_decompress_zlib	(const uint8_t *, const size_t, uint8_t **, size_t *);
 mtbl_res _mtbl_decompress_zstd	(const uint8_t *, const size_t, uint8_t **, size_t *);
 
-/* iter */
-
-struct mtbl_iter *
-mtbl_iter_init(mtbl_iter_seek_func, mtbl_iter_next_func, mtbl_iter_free_func, void *clos);
-
 /* metadata */
 
 struct mtbl_metadata {

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -134,6 +134,13 @@ typedef mtbl_res
 typedef void
 (*mtbl_iter_free_func)(void *);
 
+struct mtbl_iter *
+mtbl_iter_init(
+	mtbl_iter_seek_func,
+	mtbl_iter_next_func,
+	mtbl_iter_free_func,
+	void *clos);
+
 void
 mtbl_iter_destroy(struct mtbl_iter **);
 

--- a/mtbl/sorter.c
+++ b/mtbl/sorter.c
@@ -176,7 +176,6 @@ _mtbl_sorter_write_chunk(struct mtbl_sorter *s)
 	struct mtbl_writer *w = mtbl_writer_init_fd(c->fd, wopt);
 	mtbl_writer_options_destroy(&wopt);
 
-	size_t entries_written = 0;
 	struct entry **array = entry_vec_data(s->vec);
 	qsort(array, entry_vec_size(s->vec), sizeof(void *), _mtbl_sorter_compare);
 	for (unsigned i = 0; i < entry_vec_size(s->vec); i++) {
@@ -217,7 +216,6 @@ _mtbl_sorter_write_chunk(struct mtbl_sorter *s)
 				      entry_key(ent), ent->len_key,
 				      entry_val(ent), ent->len_val);
 		free(ent);
-		entries_written += 1;
 		if (res != mtbl_res_success)
 			break;
 	}

--- a/t/test-fileset-filter.c
+++ b/t/test-fileset-filter.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
 
 #include <mtbl.h>
 

--- a/t/test-varint.c
+++ b/t/test-varint.c
@@ -8,6 +8,62 @@
 
 #define NAME	"test-varint"
 
+
+/* Test invalid varint encoding. */
+static int
+test4(void)
+{
+	uint64_t val_64;
+	uint32_t val_32;
+	size_t len;
+	int ret = 0;
+
+	/*
+	 * A varint will continue to decode so long as the present byte has the
+	 * 0x80 bit set, or until the maximum encoded length has been reached.
+	 * For a 32bit varint, the max len is 5 bytes, and the 5th byte MUST
+	 * be <= 0x80 in value, or decoding will fail.
+	 */
+	static uint8_t bad_varint_1[5] = "\xab\xc1\x91\x98\x7f";
+
+	len = mtbl_varint_decode32(bad_varint_1, &val_32);
+	if (len != 5 || val_32 != 4077150379)
+		return 1;
+
+	bad_varint_1[4]++;	/* Corrupt the last byte to be >= 0x80 */
+	len = mtbl_varint_decode32(bad_varint_1, &val_32);
+	if (len != 0 || val_32 != 0)
+		return 1;
+
+	/* Set the second to last byte to zero and the length decreases. */
+	bad_varint_1[3] = 0;
+	len = mtbl_varint_decode32(bad_varint_1, &val_32);
+	if (len != 4)
+		return 1;
+
+	/*
+	 * We do essentially the same thing with a 64bit varint, except here the
+	 * maximum encoded length is 10 bytes rather than 5.
+	 */
+	static uint8_t bad_varint_2[10] = "\xff\xc1\x91\x98\x81\xff\xe3\x98\x87\x7f";
+
+	len = mtbl_varint_decode64(bad_varint_2, &val_64);
+	if (len != 10 || val_64 != 9741725764612808959UL)
+		return 1;
+
+	bad_varint_2[9]++;	/* corrupt the last byte to be >= 0x80 */
+	len = mtbl_varint_decode64(bad_varint_2, &val_64);
+	if (len != 0 || val_64 != 0)
+		return 1;
+
+	bad_varint_2[8] = 0;	/* truncate the decoding at 2nd to last byte */
+	len = mtbl_varint_decode64(bad_varint_2, &val_64);
+	if (len != 9)
+		return 1;
+
+	return ret;
+}
+
 static int
 test3(void)
 {
@@ -167,6 +223,7 @@ main(int argc, char **argv)
 	ret |= check(test1(), "test1");
 	ret |= check(test2(), "test2");
 	ret |= check(test3(), "test3");
+	ret |= check(test4(), "test3");
 
 	if (ret)
 		return (EXIT_FAILURE);

--- a/t/test-varint.c
+++ b/t/test-varint.c
@@ -223,7 +223,7 @@ main(int argc, char **argv)
 	ret |= check(test1(), "test1");
 	ret |= check(test2(), "test2");
 	ret |= check(test3(), "test3");
-	ret |= check(test4(), "test3");
+	ret |= check(test4(), "test4");
 
 	if (ret)
 		return (EXIT_FAILURE);


### PR DESCRIPTION
Changes in this release:
 * Return mtbl_iter_init() to public API
 * Further optimizations to mtbl_iter_seek() for mtbl_reader and mtbl_merger
 * Streamline mtbl varint decoding