### PR TITLE
Build shared library on cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ mtbl_libmtbl_la_SOURCES = \
 
 mtbl_libmtbl_la_LIBADD = -lsnappy -lz $(liblz4_LIBS) $(libzstd_LIBS)
 mtbl_libmtbl_la_LDFLAGS = $(AM_LDFLAGS) \
+	-no-undefined \
 	-version-info $(LIBMTBL_VERSION_INFO)
 if HAVE_LD_VERSION_SCRIPT
 mtbl_libmtbl_la_LDFLAGS += \


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.4.10-1.x86_64 2023-11-29 12:12 UTC x86_64 unknown unknown Cygwin
$ cd /usr/src
$ git clone https://github.com/farsightsec/mtbl.git
$ cd mtbl
$ ./configure --enable-shared --disable-static
$ make
: 
/bin/sh ./libtool  --tag=CC   --mode=link gcc -Wall -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wpointer-arith -Wsign-compare -Wchar-subscripts -Wstrict-prototypes -Wshadow -Wformat-security   -g -O2  -version-info 3:1:2 -Wl,--version-script=./mtbl/libmtbl.sym   -o mtbl/libmtbl.la -rpath /usr/local/lib libmy/crc32c.lo libmy/crc32c-slicing.lo libmy/crc32c-sse42.lo libmy/heap.lo libmy/my_fileset.lo mtbl/block.lo mtbl/block_builder.lo mtbl/compression.lo mtbl/crc32c_wrap.lo mtbl/fileset.lo mtbl/fixed.lo mtbl/iter.lo mtbl/merger.lo mtbl/reader.lo mtbl/sorter.lo mtbl/source.lo mtbl/metadata.lo mtbl/varint.lo mtbl/writer.lo -lsnappy -lz -llz4 -lzstd -lz -lsnappy
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
```

Due to Windows platform limitations, this option is required when building shared libraries.
Without this option, only static libraries can be built.

https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
> This option should be used if the package has been ported to build clean dlls on win32 platforms. Usually this means that any library data items are exported with __declspec(dllexport) and imported with __declspec(dllimport). If this option is not used, libtool will assume that the package libraries are not dll clean and will build only static libraries on win32 hosts.
> 
> Provision must be made to pass -no-undefined to libtool in link mode from the package Makefile. Naturally, if you pass -no-undefined, you must ensure that all the library symbols really are defined at link time!
