### PR TITLE
mtbl 1.7.0 - Add multithreading support to mtbl_writer, mtbl_sorter, mtbl_merge

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+mtbl (1.7.0)
+
+  * Add public mtbl_threadpool API, enabling multithreaded functionality for
+    mtbl_writer and mtbl_sorter objects; see mtbl_threadpool manpage for more
+    info.
+  * Add mtbl_writer_options_set_threadpool() to enable multithreaded
+    data block compression.
+  * Add mtbl_sorter_options_set_threadpool() to enable multithreaded sorting.
+  * Add -t option for setting the preferred number of threads to use in an
+    mtbl_threadpool object used for writing in mtbl_merge.
+
 mtbl (1.6.1)
 
   * Add ./configure --with-coverage option to build with code coverage

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,6 +86,8 @@ mtbl_libmtbl_la_SOURCES = \
 	mtbl/reader.c \
 	mtbl/sorter.c \
 	mtbl/source.c \
+	mtbl/threadpool.c \
+	mtbl/threadpool.h \
 	mtbl/metadata.c \
 	mtbl/varint.c \
 	mtbl/writer.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -272,6 +272,7 @@ dist_man_MANS = \
 	man/mtbl_crc32c.3 \
 	man/mtbl_fixed.3 \
 	man/mtbl_varint.3 \
+	man/mtbl_threadpool.3 \
 	man/mtbl.7
 
 EXTRA_DIST += \
@@ -290,4 +291,5 @@ EXTRA_DIST += \
 	man/mtbl_crc32c.3.txt \
 	man/mtbl_fixed.3.txt \
 	man/mtbl_varint.3.txt \
+	man/mtbl_threadpool.3.txt \
 	man/mtbl.7.txt

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,7 @@ fi
 ##
 #
 
-LIBMTBL_VERSION_INFO=3:2:2
+LIBMTBL_VERSION_INFO=4:0:3
 
 include_HEADERS = mtbl/mtbl.h
 lib_LTLIBRARIES = mtbl/libmtbl.la

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ discretion of the `mtbl` library user.
 `mtbl` SSTable files consist of a sequence of data blocks containing sorted
 key-value pairs, where keys and values are arbitrary byte arrays. Data blocks
 are optionally compressed using the
-[zlib](http://www.zlib.net/), [LZ4](https://github.com/Cyan4973/lz4), 
+[zlib](http://www.zlib.net/), [LZ4](https://github.com/Cyan4973/lz4),
 [zstd](https://github.com/facebook/zstd), or
 [Snappy](http://google.github.io/snappy/) compression algorithms. The data
 blocks are followed by an index block, allowing for fast searches over the
@@ -35,7 +35,7 @@ key in each data block is buffered in memory until the writer object is closed,
 at which point the index is written to the end of the SSTable file. This allows
 SSTable files to be written in a single pass with sequential I/O operations
 only.
-    
+
 Once written, SSTable files can be searched using the `mtbl` reader interface.
 Searches can retrieve key-value pairs based on an exact key match, a key prefix
 match, or a key range. Results are retrieved using a simple iterator interface.

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.64)
 AC_INIT([mtbl],
-        [1.6.1],
+        [1.7.0],
         [https://github.com/farsightsec/mtbl/issues],
         [mtbl],
         [https://github.com/farsightsec/mtbl])

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,12 @@ AC_SEARCH_LIBS([dlopen], [dl])
 AC_SEARCH_LIBS([clock_gettime], [rt])
 AC_CHECK_FUNCS([clock_gettime])
 
+AX_PTHREAD([
+    LIBS="$PTHREAD_LIBS $LIBS"
+    CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+    CC="$PTHREAD_CC"
+])
+
 AC_PATH_PROG([ASCIIDOC], [a2x])
 AM_CONDITIONAL([BUILD_MAN], [test -n "$ASCIIDOC"])
 if test -n "$ASCIIDOC"; then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,16 +1,3 @@
-mtbl (1.7.0-1) debian-fsi; urgency=medium
-
-  * Add public mtbl_threadpool API, enabling multithreaded functionality for
-    mtbl_writer and mtbl_sorter objects; see mtbl_threadpool manpage for more
-    info.
-  * Add mtbl_writer_options_set_threadpool() to enable multithreaded
-    data block compression.
-  * Add mtbl_sorter_options_set_threadpool() to enable multithreaded sorting.
-  * Add -t option for setting the preferred number of threads to use in an
-    mtbl_threadpool object used for writing in mtbl_merge.
-
- -- Farsight Security Inc <software@farsightsecurity.com>  Tue, 23 Jul 2024 16:18:20 -0800
-
 mtbl (1.6.1-1) debian-fsi; urgency=medium
 
   * Add ./configure --with-coverage option to build with code coverage

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+mtbl (1.7.0-1) debian-fsi; urgency=medium
+
+  * Add public mtbl_threadpool API, enabling multithreaded functionality for
+    mtbl_writer and mtbl_sorter objects; see mtbl_threadpool manpage for more
+    info.
+  * Add mtbl_writer_options_set_threadpool() to enable multithreaded
+    data block compression.
+  * Add mtbl_sorter_options_set_threadpool() to enable multithreaded sorting.
+  * Add -t option for setting the preferred number of threads to use in an
+    mtbl_threadpool object used for writing in mtbl_merge.
+
+ -- Farsight Security Inc <software@farsightsecurity.com>  Tue, 23 Jul 2024 16:18:20 -0800
+
 mtbl (1.6.1-1) debian-fsi; urgency=medium
 
   * Add ./configure --with-coverage option to build with code coverage

--- a/debian/libmtbl1.symbols
+++ b/debian/libmtbl1.symbols
@@ -92,5 +92,6 @@ libmtbl.so.1 libmtbl1 #MINVER#
  mtbl_writer_options_set_block_size@LIBMTBL_1.0.0 1.0.0
  mtbl_writer_options_set_compression@LIBMTBL_1.0.0 1.0.0
  mtbl_writer_options_set_compression_level@LIBMTBL_1.0.0 1.0.0
+ mtbl_writer_options_set_threadpool@LIBMTBL_1.5.0 1.7.0
  mtbl_threadpool_init@LIBMTBL_1.5.0 1.7.0
  mtbl_threadpool_destroy@LIBMTBL_1.5.0 1.7.0

--- a/debian/libmtbl1.symbols
+++ b/debian/libmtbl1.symbols
@@ -68,6 +68,7 @@ libmtbl.so.1 libmtbl1 #MINVER#
  mtbl_sorter_options_set_max_memory@LIBMTBL_1.0.0 1.0.0
  mtbl_sorter_options_set_merge_func@LIBMTBL_1.0.0 1.0.0
  mtbl_sorter_options_set_temp_dir@LIBMTBL_1.0.0 1.0.0
+ mtbl_sorter_options_set_threadpool@LIBMTBL_1.5.0 1.7.0
  mtbl_sorter_write@LIBMTBL_1.0.0 1.0.0
  mtbl_source_destroy@LIBMTBL_1.0.0 1.0.0
  mtbl_source_get@LIBMTBL_1.0.0 1.0.0

--- a/debian/libmtbl1.symbols
+++ b/debian/libmtbl1.symbols
@@ -3,6 +3,7 @@ libmtbl.so.1 libmtbl1 #MINVER#
  LIBMTBL_1.1.0@LIBMTBL_1.1.0 1.1.0
  LIBMTBL_1.2.0@LIBMTBL_1.2.0 1.3.0
  LIBMTBL_1.4.0@LIBMTBL_1.4.0 1.6.0
+ LIBMTBL_1.5.0@LIBMTBL_1.5.0 1.7.0
  mtbl_compress@LIBMTBL_1.0.0 1.0.0
  mtbl_compress_level@LIBMTBL_1.0.0 1.0.0
  mtbl_compression_type_from_str@LIBMTBL_1.0.0 1.0.0
@@ -91,3 +92,5 @@ libmtbl.so.1 libmtbl1 #MINVER#
  mtbl_writer_options_set_block_size@LIBMTBL_1.0.0 1.0.0
  mtbl_writer_options_set_compression@LIBMTBL_1.0.0 1.0.0
  mtbl_writer_options_set_compression_level@LIBMTBL_1.0.0 1.0.0
+ mtbl_threadpool_init@LIBMTBL_1.5.0 1.7.0
+ mtbl_threadpool_destroy@LIBMTBL_1.5.0 1.7.0

--- a/debian/libmtbl1.symbols
+++ b/debian/libmtbl1.symbols
@@ -3,7 +3,7 @@ libmtbl.so.1 libmtbl1 #MINVER#
  LIBMTBL_1.1.0@LIBMTBL_1.1.0 1.1.0
  LIBMTBL_1.2.0@LIBMTBL_1.2.0 1.3.0
  LIBMTBL_1.4.0@LIBMTBL_1.4.0 1.6.0
- LIBMTBL_1.5.0@LIBMTBL_1.5.0 1.7.0
+ LIBMTBL_1.7.0@LIBMTBL_1.7.0 1.7.0
  mtbl_compress@LIBMTBL_1.0.0 1.0.0
  mtbl_compress_level@LIBMTBL_1.0.0 1.0.0
  mtbl_compression_type_from_str@LIBMTBL_1.0.0 1.0.0
@@ -68,7 +68,7 @@ libmtbl.so.1 libmtbl1 #MINVER#
  mtbl_sorter_options_set_max_memory@LIBMTBL_1.0.0 1.0.0
  mtbl_sorter_options_set_merge_func@LIBMTBL_1.0.0 1.0.0
  mtbl_sorter_options_set_temp_dir@LIBMTBL_1.0.0 1.0.0
- mtbl_sorter_options_set_threadpool@LIBMTBL_1.5.0 1.7.0
+ mtbl_sorter_options_set_threadpool@LIBMTBL_1.7.0 1.7.0
  mtbl_sorter_write@LIBMTBL_1.0.0 1.0.0
  mtbl_source_destroy@LIBMTBL_1.0.0 1.0.0
  mtbl_source_get@LIBMTBL_1.0.0 1.0.0
@@ -77,6 +77,8 @@ libmtbl.so.1 libmtbl1 #MINVER#
  mtbl_source_init@LIBMTBL_1.0.0 1.0.0
  mtbl_source_iter@LIBMTBL_1.0.0 1.0.0
  mtbl_source_write@LIBMTBL_1.0.0 1.0.0
+ mtbl_threadpool_destroy@LIBMTBL_1.7.0 1.7.0
+ mtbl_threadpool_init@LIBMTBL_1.7.0 1.7.0
  mtbl_varint_decode32@LIBMTBL_1.0.0 1.0.0
  mtbl_varint_decode64@LIBMTBL_1.0.0 1.0.0
  mtbl_varint_encode32@LIBMTBL_1.0.0 1.0.0
@@ -93,6 +95,4 @@ libmtbl.so.1 libmtbl1 #MINVER#
  mtbl_writer_options_set_block_size@LIBMTBL_1.0.0 1.0.0
  mtbl_writer_options_set_compression@LIBMTBL_1.0.0 1.0.0
  mtbl_writer_options_set_compression_level@LIBMTBL_1.0.0 1.0.0
- mtbl_writer_options_set_threadpool@LIBMTBL_1.5.0 1.7.0
- mtbl_threadpool_init@LIBMTBL_1.5.0 1.7.0
- mtbl_threadpool_destroy@LIBMTBL_1.5.0 1.7.0
+ mtbl_writer_options_set_threadpool@LIBMTBL_1.7.0 1.7.0

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -1,0 +1,1 @@
+../libmy/m4/ax_pthread.m4

--- a/man/mtbl.7
+++ b/man/mtbl.7
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mtbl
-.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 01/31/2014
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 07/16/2024
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL" "7" "01/31/2014" "\ \&" "\ \&"
+.TH "MTBL" "7" "07/16/2024" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -118,4 +118,15 @@ Functions for fixed\-width encoding and decoding of 32 and 64 bit integers\&.
 \fBmtbl_varint\fR(3)
 .RS 4
 Functions for varint encoding and decoding of 32 and 64 bit integers\&.
+.RE
+.PP
+\fBmtbl_threadpool\fR(3)
+.RS 4
+Provides an interface for enabling multithreading on
+\fBmtbl_writer\fR
+and
+\fBmtbl_sorter\fR
+objects via
+\fBmtbl_threadpool\fR
+objects\&.
 .RE

--- a/man/mtbl.7.txt
+++ b/man/mtbl.7.txt
@@ -49,7 +49,7 @@ Sorter objects receive a sequence of key-value entries provided by the caller
 and return them in sorted order. The caller must provide a callback function
 to merge values in the case of entries with duplicate keys. The sorted output
 sequence may be retrieved via the ^mtbl_iter^ interface or be dumped to an
-^mtbl_writer^ object.  
+^mtbl_writer^ object.
 
 link:mtbl_fileset[3]::
 Fileset objects automatically maintain an ^mtbl_source^ built on top of the
@@ -66,3 +66,7 @@ Functions for fixed-width encoding and decoding of 32 and 64 bit integers.
 
 link:mtbl_varint[3]::
 Functions for varint encoding and decoding of 32 and 64 bit integers.
+
+link:mtbl_threadpool[3]::
+Provides an interface for enabling multithreading on ^mtbl_writer^ and
+^mtbl_sorter^ objects via ^mtbl_threadpool^ objects.

--- a/man/mtbl_sorter.3
+++ b/man/mtbl_sorter.3
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mtbl_sorter
-.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 01/31/2014
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 07/12/2024
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_SORTER" "3" "01/31/2014" "\ \&" "\ \&"
+.TH "MTBL_SORTER" "3" "07/12/2024" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -95,6 +95,13 @@ mtbl_sorter_options_set_max_memory(
         struct mtbl_sorter_options *\fR\fB\fIsopt\fR\fR\fB,
         size_t \fR\fB\fImax_memory\fR\fR\fB);\fR
 .fi
+.sp
+.nf
+\fBvoid
+mtbl_sorter_options_set_threadpool(
+        struct mtbl_sorter_options *\fR\fB\fIsopt\fR\fR\fB,
+        size_t \fR\fB\fImax_memory\fR\fR\fB);\fR
+.fi
 .SH "DESCRIPTION"
 .sp
 The \fBmtbl_sorter\fR interface accepts a sequence of key\-value pairs with keys in arbitrary order and provides these entries in sorted order\&. The sorted entries may be consumed via the \fBmtbl_iter\fR interface using the \fBmtbl_sorter_iter\fR() function, or they may be dumped to an \fBmtbl_writer\fR object using the \fBmtbl_sorter_write\fR() function\&. The \fBmtbl_sorter\fR implementation buffers entries in memory up to a configurable limit before sorting them and writing them to disk in chunks\&. When the caller has finishing adding entries and requests the sorted output, entries from these sorted chunks are then read back and merged\&. (Thus, \fBmtbl_sorter\fR(3) is an "external sorting" implementation\&.)
@@ -140,6 +147,9 @@ Specifies the maximum amount of memory to use for in\-memory sorting, in bytes\&
 .sp
 See \fBmtbl_merger\fR(3)\&. An \fBmtbl_merger\fR object is used internally for the external sort\&.
 .RE
+.SS "threadpool"
+.sp
+A pointer to a user\-managed \fBmtbl_threadpool\fR object which will be used to concurrently sort and write batches of entries to temporary MTBL files\&. If this pointer is equal to NULL, has not been initialized, or has been initialized with a thread_count of 0, the threadpool will not be used\&.
 .SH "RETURN VALUE"
 .sp
 If the merge function callback is unable to provide a merged value (that is, it fails to return a non\-NULL value in its \fImerged_val\fR argument), the sort process will be aborted, and \fBmtbl_sorter_write\fR() or \fBmtbl_iter_next\fR() will return \fBmtbl_res_failure\fR\&.

--- a/man/mtbl_sorter.3
+++ b/man/mtbl_sorter.3
@@ -2,12 +2,12 @@
 .\"     Title: mtbl_sorter
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 07/12/2024
+.\"      Date: 07/29/2024
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_SORTER" "3" "07/12/2024" "\ \&" "\ \&"
+.TH "MTBL_SORTER" "3" "07/29/2024" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -100,7 +100,7 @@ mtbl_sorter_options_set_max_memory(
 \fBvoid
 mtbl_sorter_options_set_threadpool(
         struct mtbl_sorter_options *\fR\fB\fIsopt\fR\fR\fB,
-        size_t \fR\fB\fImax_memory\fR\fR\fB);\fR
+        struct mtbl_threadpool *\fR\fB\fIpool\fR\fR\fB);\fR
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -149,7 +149,7 @@ See \fBmtbl_merger\fR(3)\&. An \fBmtbl_merger\fR object is used internally for t
 .RE
 .SS "threadpool"
 .sp
-A pointer to a user\-managed \fBmtbl_threadpool\fR object which will be used to concurrently sort and write batches of entries to temporary MTBL files\&. If this pointer is equal to NULL, has not been initialized, or has been initialized with a thread_count of 0, the threadpool will not be used\&.
+A pointer to a user\-managed \fBmtbl_threadpool\fR object which will be used to concurrently sort and write batches of entries to temporary MTBL files\&. If this pointer is equal to NULL, has not been initialized, or has been initialized with a thread count of 0, the threadpool will not be used\&.
 .SH "RETURN VALUE"
 .sp
 If the merge function callback is unable to provide a merged value (that is, it fails to return a non\-NULL value in its \fImerged_val\fR argument), the sort process will be aborted, and \fBmtbl_sorter_write\fR() or \fBmtbl_iter_next\fR() will return \fBmtbl_res_failure\fR\&.

--- a/man/mtbl_sorter.3.txt
+++ b/man/mtbl_sorter.3.txt
@@ -120,7 +120,7 @@ external sort.
 A pointer to a user-managed ^mtbl_threadpool^ object which will be used to
 concurrently sort and write batches of entries to temporary MTBL files. If this
 pointer is equal to NULL, has not been initialized, or has been initialized
-with a thread_count of 0, the threadpool will not be used.
+with a thread count of 0, the threadpool will not be used.
 
 == RETURN VALUE ==
 

--- a/man/mtbl_sorter.3.txt
+++ b/man/mtbl_sorter.3.txt
@@ -61,6 +61,12 @@ mtbl_sorter_options_set_max_memory(
         struct mtbl_sorter_options *'sopt',
         size_t 'max_memory');^
 
+[verse]
+^void
+mtbl_sorter_options_set_threadpool(
+	struct mtbl_sorter_options *'sopt',
+	struct mtbl_threadpool *'pool');^
+
 == DESCRIPTION ==
 
 The ^mtbl_sorter^ interface accepts a sequence of key-value pairs with keys in
@@ -109,6 +115,12 @@ allocated for key-value entries and does not include any allocation overhead.
 ==== merge_func ====
 See ^mtbl_merger^(3). An ^mtbl_merger^ object is used internally for the
 external sort.
+
+=== threadpool ===
+A pointer to a user-managed ^mtbl_threadpool^ object which will be used to
+concurrently sort and write batches of entries to temporary MTBL files. If this
+pointer is equal to NULL, has not been initialized, or has been initialized
+with a thread_count of 0, the threadpool will not be used.
 
 == RETURN VALUE ==
 

--- a/man/mtbl_threadpool.3
+++ b/man/mtbl_threadpool.3
@@ -1,0 +1,66 @@
+'\" t
+.\"     Title: mtbl_threadpool
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 07/10/2024
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "MTBL_THREADPOOL" "3" "07/10/2024" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+mtbl_threadpool \- create a shared threadpool
+.SH "SYNOPSIS"
+.sp
+\fB#include <mtbl\&.h>\fR
+.sp
+Threadpool objects:
+.sp
+.nf
+\fBstruct mtbl_threadpool *
+mtbl_threadpool_init(size_t \fR\fB\fIthread_count\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBvoid
+mtbl_threadpool_destroy(struct mtbl_threadpool **\fR\fB\fIpool\fR\fR\fB);\fR
+.fi
+.SH "DESCRIPTION"
+.sp
+Certain MTBL "option" structures accept an \fBmtbl_threadpool\fR option (e\&.g\&. \fBmtbl_writer_options\fR) to enable internal concurrency\&. The user\-provided \fBmtbl_threadpool\fR object must be initialized before use by calling \fBmtbl_threadpool_init()\fR, and must be destroyed after use by calling \fBmtbl_threadpool_destroy()\fR\&.
+.sp
+If the \fIthread_count\fR parameter to \fBmtbl_threadpool_init()\fR is 0, multithreading will be disabled\&. Regardless, a non\-NULL \fBmtbl_threadpool\fR object will be returned from \fBmtbl_threadpool_init()\fR\&.
+.SS "Threadpool options"
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBthread_count\fR
+.RS 4
+.sp
+The maximum number of worker threads that the threadpool will open\&.
+.RE
+.SH "RETURN VALUE"
+.sp
+\fBmtbl_threadpool_init\fR() returns NULL on failure, and non\-NULL on success\&.

--- a/man/mtbl_threadpool.3
+++ b/man/mtbl_threadpool.3
@@ -28,12 +28,10 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-mtbl_threadpool \- create a shared threadpool
+mtbl_threadpool \- create a shared worker threadpool
 .SH "SYNOPSIS"
 .sp
 \fB#include <mtbl\&.h>\fR
-.sp
-Threadpool objects:
 .sp
 .nf
 \fBstruct mtbl_threadpool *
@@ -46,7 +44,7 @@ mtbl_threadpool_destroy(struct mtbl_threadpool **\fR\fB\fIpool\fR\fR\fB);\fR
 .fi
 .SH "DESCRIPTION"
 .sp
-Certain MTBL "option" structures accept an \fBmtbl_threadpool\fR option (e\&.g\&. \fBmtbl_writer_options\fR) to enable internal concurrency\&. The user\-provided \fBmtbl_threadpool\fR object must be initialized before use by calling \fBmtbl_threadpool_init()\fR, and must be destroyed after use by calling \fBmtbl_threadpool_destroy()\fR\&.
+Certain MTBL "option" structures accept an \fBmtbl_threadpool\fR option (e\&.g\&. \fBmtbl_writer_options\fR, \fBmtbl_sorter_options\fR) to enable internal concurrency\&. The user\-provided \fBmtbl_threadpool\fR object must be initialized before use by calling \fBmtbl_threadpool_init()\fR, and must be destroyed after use by calling \fBmtbl_threadpool_destroy()\fR\&.
 .sp
 If the \fIthread_count\fR parameter to \fBmtbl_threadpool_init()\fR is 0, multithreading will be disabled\&. Regardless, a non\-NULL \fBmtbl_threadpool\fR object will be returned from \fBmtbl_threadpool_init()\fR\&.
 .SS "Threadpool options"

--- a/man/mtbl_threadpool.3.txt
+++ b/man/mtbl_threadpool.3.txt
@@ -1,0 +1,40 @@
+= mtbl_threadpool(3) =
+
+== NAME ==
+
+mtbl_threadpool - create a shared threadpool
+
+== SYNOPSIS ==
+
+^#include <mtbl.h>^
+
+Threadpool objects:
+
+[verse]
+^struct mtbl_threadpool *
+mtbl_threadpool_init(size_t 'thread_count');^
+
+[verse]
+^void
+mtbl_threadpool_destroy(struct mtbl_threadpool **'pool');^
+
+== DESCRIPTION ==
+
+Certain MTBL "option" structures accept an ^mtbl_threadpool^ option (e.g.
+^mtbl_writer_options^, ^mtbl_sorter_options^) to enable internal concurrency.
+The user-provided ^mtbl_threadpool^ object must be initialized before use by
+calling ^mtbl_threadpool_init()^, and must be destroyed after use by calling
+^mtbl_threadpool_destroy()^.
+
+If the _thread_count_ parameter to ^mtbl_threadpool_init()^ is 0,
+multithreading will be disabled.  Regardless, a non-NULL ^mtbl_threadpool^
+object will be returned from ^mtbl_threadpool_init()^.
+
+=== Threadpool options ===
+
+==== thread_count ====
+The maximum number of worker threads that the threadpool will open.
+
+== RETURN VALUE ==
+
+^mtbl_threadpool_init^() returns NULL on failure, and non-NULL on success.

--- a/man/mtbl_threadpool.3.txt
+++ b/man/mtbl_threadpool.3.txt
@@ -2,13 +2,11 @@
 
 == NAME ==
 
-mtbl_threadpool - create a shared threadpool
+mtbl_threadpool - create a shared worker threadpool
 
 == SYNOPSIS ==
 
 ^#include <mtbl.h>^
-
-Threadpool objects:
 
 [verse]
 ^struct mtbl_threadpool *

--- a/man/mtbl_writer.3
+++ b/man/mtbl_writer.3
@@ -2,12 +2,12 @@
 .\"     Title: mtbl_writer
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 07/10/2024
+.\"      Date: 07/29/2024
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_WRITER" "3" "07/10/2024" "\ \&" "\ \&"
+.TH "MTBL_WRITER" "3" "07/29/2024" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -146,7 +146,7 @@ Specifies the compression level to use on data blocks, if the selected compressi
 \fBthreadpool\fR
 .RS 4
 .sp
-A pointer to a user\-managed \fBmtbl_threadpool\fR object which will be used to concurrently compress data blocks\&. If this pointer is equal to \fBNULL\fR, has not been initialized, or has been initialized with a \fBthread_count\fR of 0, the threadpool will not be used\&.
+A pointer to a user\-managed \fBmtbl_threadpool\fR object which will be used to concurrently compress data blocks\&. If this pointer is equal to \fBNULL\fR, has not been initialized, or has been initialized with a thread count of 0, the threadpool will not be used\&.
 .RE
 .sp
 .it 1 an-trap

--- a/man/mtbl_writer.3
+++ b/man/mtbl_writer.3
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: mtbl_writer
-.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 12/11/2016
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 07/10/2024
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "MTBL_WRITER" "3" "12/11/2016" "\ \&" "\ \&"
+.TH "MTBL_WRITER" "3" "07/10/2024" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -85,6 +85,13 @@ mtbl_writer_options_set_compression_level(
 .sp
 .nf
 \fBvoid
+mtbl_writer_options_set_threadpool(
+        struct mtbl_writer_options *\fR\fB\fIwopt\fR\fR\fB,
+        struct mtbl_threadpool \fR\fB\fIthreadpool\fR\fR\fB);\fR
+.fi
+.sp
+.nf
+\fBvoid
 mtbl_writer_options_set_block_size(
         struct mtbl_writer_options *\fR\fB\fIwopt\fR\fR\fB,
         size_t \fR\fB\fIblock_size\fR\fR\fB);\fR
@@ -129,6 +136,17 @@ Specifies the compression algorithm to use on data blocks\&. Possible values are
 .RS 4
 .sp
 Specifies the compression level to use on data blocks, if the selected compression algorithm supports different compression levels\&. The compression algorithms which support different compression levels are \fBMTBL_COMPRESSION_LZ4HC\fR (0\-16), \fBMTBL_COMPRESSION_ZSTD\fR (1\-22), and \fBMTBL_COMPRESSION_ZLIB\fR (0\-9)\&. Other compression algorithms ignore this option, and compression levels outside the ranges supported by the algorithm will be silently clamped to the minimum or maximum supported level\&. If not specified, a reasonable default will be used\&.
+.RE
+.sp
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBthreadpool\fR
+.RS 4
+.sp
+A pointer to a user\-managed \fBmtbl_threadpool\fR object which will be used to concurrently compress data blocks\&. If this pointer is equal to \fBNULL\fR, has not been initialized, or has been initialized with a \fBthread_count\fR of 0, the threadpool will not be used\&.
 .RE
 .sp
 .it 1 an-trap

--- a/man/mtbl_writer.3.txt
+++ b/man/mtbl_writer.3.txt
@@ -120,7 +120,7 @@ reasonable default will be used.
 ==== threadpool ====
 A pointer to a user-managed ^mtbl_threadpool^ object which will be used to
 concurrently compress data blocks.  If this pointer is equal to ^NULL^, has not
-been initialized, or has been initialized with a ^thread_count^ of 0, the
+been initialized, or has been initialized with a thread count of 0, the
 threadpool will not be used.
 
 ==== block_size ====

--- a/man/mtbl_writer.3.txt
+++ b/man/mtbl_writer.3.txt
@@ -52,6 +52,12 @@ mtbl_writer_options_set_compression_level(
 
 [verse]
 ^void
+mtbl_writer_options_set_threadpool(
+	struct mtbl_writer_options *'wopt',
+	struct mtbl_threadpool 'threadpool');^
+
+[verse]
+^void
 mtbl_writer_options_set_block_size(
         struct mtbl_writer_options *'wopt',
         size_t 'block_size');^
@@ -85,7 +91,7 @@ an _fd_ argument specifying an open, writable file descriptor. Prior to the
 call, moving _fd_'s cursor via ^write^(2) or ^lseek^(2) will have the effect
 of reserving the file's initial bytes for non-MTBL use. MTBL will only write
 at, or above the current offset. Thereafter, only ^mtbl_writer^ may access this
-_fd_ (including closing it), and no other writes may be made to the underlying 
+_fd_ (including closing it), and no other writes may be made to the underlying
 file above the first offset of the MTBL data. The MTBL data must be last in the
 file.
 
@@ -110,6 +116,12 @@ algorithms which support different compression levels are
 and compression levels outside the ranges supported by the algorithm will be
 silently clamped to the minimum or maximum supported level. If not specified, a
 reasonable default will be used.
+
+==== threadpool ====
+A pointer to a user-managed ^mtbl_threadpool^ object which will be used to
+concurrently compress data blocks.  If this pointer is equal to ^NULL^, has not
+been initialized, or has been initialized with a ^thread_count^ of 0, the
+threadpool will not be used.
 
 ==== block_size ====
 The maximum size of uncompressed data blocks, specified in bytes. The default

--- a/mtbl.spec
+++ b/mtbl.spec
@@ -1,5 +1,5 @@
 Name:           mtbl
-Version:        1.6.1
+Version:        1.7.0
 Release:        1%{?dist}
 Summary:	immutable sorted string table utilities
 
@@ -9,7 +9,7 @@ Source0:        https://dl.farsightsecurity.com/dist/%{name}/%{name}-%{version}.
 
 
 BuildRequires:  zlib-devel lz4-devel libzstd-devel snappy-devel
-#Requires:       
+#Requires:
 # TODO: will Requires be set automatically?
 
 %description

--- a/mtbl/libmtbl.sym
+++ b/mtbl/libmtbl.sym
@@ -107,6 +107,7 @@ global:
 LIBMTBL_1.5.0 {
 global:
 	mtbl_writer_options_set_threadpool;
+	mtbl_sorter_options_set_threadpool;
 	mtbl_threadpool_init;
 	mtbl_threadpool_destroy;
 } LIBMTBL_1.4.0;

--- a/mtbl/libmtbl.sym
+++ b/mtbl/libmtbl.sym
@@ -103,3 +103,9 @@ LIBMTBL_1.4.0 {
 global:
         mtbl_fileset_options_set_reader_filter_func;
 } LIBMTBL_1.2.0;
+
+LIBMTBL_1.5.0 {
+global:
+	mtbl_threadpool_init;
+	mtbl_threadpool_destroy;
+} LIBMTBL_1.4.0;

--- a/mtbl/libmtbl.sym
+++ b/mtbl/libmtbl.sym
@@ -106,6 +106,7 @@ global:
 
 LIBMTBL_1.5.0 {
 global:
+	mtbl_writer_options_set_threadpool;
 	mtbl_threadpool_init;
 	mtbl_threadpool_destroy;
 } LIBMTBL_1.4.0;

--- a/mtbl/libmtbl.sym
+++ b/mtbl/libmtbl.sym
@@ -104,7 +104,7 @@ global:
         mtbl_fileset_options_set_reader_filter_func;
 } LIBMTBL_1.2.0;
 
-LIBMTBL_1.5.0 {
+LIBMTBL_1.7.0 {
 global:
 	mtbl_writer_options_set_threadpool;
 	mtbl_sorter_options_set_threadpool;

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -263,6 +263,11 @@ mtbl_writer_options_set_block_restart_interval(
 	struct mtbl_writer_options *,
 	size_t);
 
+void
+mtbl_writer_options_set_threadpool(
+	struct mtbl_writer_options *,
+	struct mtbl_threadpool *);
+
 /* reader */
 
 struct mtbl_reader *

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -481,6 +481,11 @@ mtbl_sorter_options_set_max_memory(
 	struct mtbl_sorter_options *,
 	size_t);
 
+void
+mtbl_sorter_options_set_threadpool(
+	struct mtbl_sorter_options *,
+	struct mtbl_threadpool *);
+
 /* crc32c */
 
 uint32_t

--- a/mtbl/mtbl.h
+++ b/mtbl/mtbl.h
@@ -77,6 +77,8 @@ mtbl_compression_type_from_str(const char *, mtbl_compression_type *);
 
 /* exported types */
 
+struct mtbl_threadpool;
+
 struct mtbl_iter;
 struct mtbl_source;
 
@@ -117,6 +119,14 @@ typedef bool
 
 typedef bool
 (*mtbl_reader_filter_func)(struct mtbl_reader *reader, void *clos);
+
+/* threadpool */
+
+struct mtbl_threadpool *
+mtbl_threadpool_init(size_t thread_count);
+
+void
+mtbl_threadpool_destroy(struct mtbl_threadpool **pool);
 
 /* iter */
 

--- a/mtbl/sorter.c
+++ b/mtbl/sorter.c
@@ -16,6 +16,7 @@
 
 #include "mtbl-private.h"
 #include "threadpool.h"
+
 #include "libmy/ubuf.h"
 
 
@@ -64,7 +65,7 @@ struct entry_batch {
 
 
 static struct entry_batch *_mtbl_sorter_get_entry_batch(struct mtbl_sorter *);
-static struct mtbl_reader * _mtbl_sorter_write_chunk(struct entry_batch *);
+static struct mtbl_reader *_mtbl_sorter_write_chunk(struct entry_batch *);
 static mtbl_res _mtbl_sorter_flush(struct mtbl_sorter *);
 static void* _write_temp_file_wrapper(void *batch);
 static void _collect_readers_cb(void *result, void *sorter);
@@ -254,8 +255,7 @@ _mtbl_sorter_write_chunk(struct entry_batch *b)
 	if (res != mtbl_res_success)
 		return (NULL);
 
-	struct mtbl_reader *r = mtbl_reader_init_fd(fd, NULL);
-	return (r);
+	return (mtbl_reader_init_fd(fd, NULL));
 }
 
 mtbl_res
@@ -312,9 +312,11 @@ mtbl_sorter_add(struct mtbl_sorter *s,
 static mtbl_res
 _mtbl_sorter_flush(struct mtbl_sorter *s)
 {
-	assert(!s->iterating);
 	mtbl_res res = mtbl_res_success;
-	struct entry_batch *b = _mtbl_sorter_get_entry_batch(s);
+	struct entry_batch *b;
+
+	assert(!s->iterating);
+	b = _mtbl_sorter_get_entry_batch(s);
 
 	if (s->pool != NULL) {
 		threadpool_dispatch(
@@ -337,9 +339,11 @@ _mtbl_sorter_flush(struct mtbl_sorter *s)
 static struct entry_batch *
 _mtbl_sorter_get_entry_batch(struct mtbl_sorter *s)
 {
+	struct entry_batch *b;
+
 	assert(!s->iterating);
 
-	struct entry_batch *b = calloc(1, sizeof(*b));
+	b = calloc(1, sizeof(*b));
 	b->s = s;
 	b->entries = s->vec;
 
@@ -349,8 +353,8 @@ _mtbl_sorter_get_entry_batch(struct mtbl_sorter *s)
 	return b;
 }
 
-static void* _write_temp_file_wrapper(void *batch) {
-
+static void *
+_write_temp_file_wrapper(void *batch) {
 	struct mtbl_reader *r = _mtbl_sorter_write_chunk(batch);
 	return r;
 }

--- a/mtbl/threadpool.c
+++ b/mtbl/threadpool.c
@@ -49,14 +49,16 @@ mtbl_threadpool_destroy(struct mtbl_threadpool **poolp) {
 
 /* Threadpool */
 
+/* The worker threads which will be wholly managed by a struct threadpool object. */
 struct thread {
 	pthread_mutex_t m;
 	pthread_cond_t c;
 	pthread_t t;
 
-	void *arg, *res;
+	void *arg;	/* Job data for this thread to work on. */
+	void *res;	/* Result data of this thread's work. */
 
-	thread_cb cb;
+	thread_cb cb;	/* Callback for when this thread receives a job. */
 
 	struct thread *next;
 	struct resultq *rq;
@@ -65,6 +67,7 @@ struct thread {
 	bool running;
 };
 
+/* Queue of worker threads' completed work that is awaiting processing. */
 struct resultq {
 	pthread_mutex_t m;
 	pthread_cond_t c;
@@ -75,6 +78,7 @@ struct resultq {
 	struct thread *head, **ptail;
 };
 
+/* Manages all worker threads. */
 struct threadpool {
 	pthread_mutex_t m;
 	pthread_cond_t c;
@@ -84,11 +88,12 @@ struct threadpool {
 	size_t max;
 };
 
+/* Handles all results received by worker threads. */
 struct result_handler {
 	pthread_t thread;
 	struct resultq *rq;
-	result_cb cb;
-	void *cbdata;
+	result_cb cb;	/* Callback for when completed work is received. */
+	void *cbdata;	/* Argument which will be passed to result_cb cb(). */
 };
 
 /*

--- a/mtbl/threadpool.c
+++ b/mtbl/threadpool.c
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2024 DomainTools LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <pthread.h>
+#include <assert.h>
+#include <stdbool.h>
+
+#include "threadpool.h"
+
+struct thread {
+	pthread_mutex_t m;
+	pthread_cond_t c;
+	pthread_t t;
+
+	void *arg, *res;
+
+	thread_cb cb;
+
+	struct thread *next;
+	struct resultq *rq;
+	struct threadpool *pool;
+
+	bool running;
+};
+
+struct resultq {
+	pthread_mutex_t m;
+	pthread_cond_t c;
+
+	bool finished;
+	size_t nthreads;
+
+	struct thread *head, **ptail;
+};
+
+struct threadpool {
+	pthread_mutex_t m;
+	pthread_cond_t c;
+	struct thread *head;
+
+	size_t count;
+	size_t max;
+};
+
+struct result_handler {
+	pthread_t thread;
+	struct resultq *rq;
+	result_cb cb;
+	void *cbdata;
+};
+
+/* Threadpool */
+
+static void *
+thread_worker(void *arg)
+{
+	struct thread *me = arg;
+
+	for (;;) {
+		struct resultq *rq;
+
+		pthread_mutex_lock(&me->m);
+		while (!me->running)
+			pthread_cond_wait(&me->c, &me->m);
+		pthread_mutex_unlock(&me->m);
+
+		if (me->cb == NULL)
+			break;
+
+		me->res = me->cb(me->arg);
+		me->cb = NULL;
+		me->arg = NULL;
+
+		rq = me->rq;
+		me->rq = NULL;
+
+		if (rq != NULL) {
+			/*
+			 * We were dispatched with ordered = false; place self
+			 * onto given queue when finished. Since the thread enters
+			 * the queue in a finished state (running = false), there
+			 * is no need to signal the thread condition.
+			 */
+			me->running = false;
+
+			pthread_mutex_lock(&rq->m);
+			*rq->ptail = me;
+			rq->ptail = &me->next;
+			pthread_cond_signal(&rq->c);
+			pthread_mutex_unlock(&rq->m);
+		} else {
+			pthread_mutex_lock(&me->m);
+			me->running = false;
+			pthread_cond_signal(&me->c);
+			pthread_mutex_unlock(&me->m);
+		}
+	}
+
+	return NULL;
+}
+
+struct threadpool *
+threadpool_init(size_t max_threads)
+{
+	struct threadpool *pool = calloc(1, sizeof(*pool));
+
+	pthread_mutex_init(&pool->m, NULL);
+	pthread_cond_init(&pool->c, NULL);
+	pool->max = max_threads;
+
+	return pool;
+}
+
+static struct thread *
+threadpool_next(struct threadpool *pool)
+{
+	struct thread *thr = NULL;
+
+	pthread_mutex_lock(&pool->m);
+
+	while (pool->head == NULL && pool->count == pool->max) {
+		pthread_cond_wait(&pool->c, &pool->m);
+	}
+
+	if (pool->head != NULL) {
+		thr = pool->head;
+		pool->head = thr->next;
+		thr->next = NULL;
+		assert(thr->cb == NULL);
+		assert(thr->res == NULL);
+		assert(!thr->running);
+	} else {
+		pool->count++;
+	}
+
+	pthread_mutex_unlock(&pool->m);
+
+	if (thr == NULL) {
+		thr = calloc(1, sizeof(*thr));
+		thr->pool = pool;
+		pthread_mutex_init(&thr->m, NULL);
+		pthread_cond_init(&thr->c, NULL);
+		pthread_create(&thr->t, NULL, thread_worker, thr);
+	}
+
+	return thr;
+}
+
+void
+threadpool_dispatch(struct threadpool *pool,
+		    struct result_handler *rh,
+		    bool ordered,
+		    thread_cb cb,
+		    void *arg)
+{
+	struct resultq *rq = rh->rq;
+	struct thread *thr = threadpool_next(pool);
+
+	assert(!thr->running);
+	assert(thr->next == NULL);
+
+	pthread_mutex_lock(&thr->m);
+	thr->rq = ordered?NULL:rq;
+	thr->cb = cb;
+	thr->arg = arg;
+	thr->running = true;
+	pthread_cond_signal(&thr->c);
+	pthread_mutex_unlock(&thr->m);
+
+	pthread_mutex_lock(&rq->m);
+	assert(!rq->finished);
+	rq->nthreads++;
+	if (ordered) {
+		*rq->ptail = thr;
+		rq->ptail = &thr->next;
+		pthread_cond_signal(&rq->c);
+	}
+	pthread_mutex_unlock(&rq->m);
+}
+
+void
+threadpool_destroy(struct threadpool **poolp)
+{
+	struct threadpool *pool = *poolp;
+	struct thread *thr;
+
+	if (pool == NULL)
+		return;
+
+	pthread_mutex_lock(&pool->m);
+	while (pool->count > 0) {
+		while (pool->head == NULL)
+			pthread_cond_wait(&pool->c, &pool->m);
+
+		thr = pool->head;
+		pool->head = thr->next;
+
+		assert(thr->cb == NULL);
+
+		/* Wake up thread with NULL callback, signaling exit */
+		pthread_mutex_lock(&thr->m);
+		thr->running = true;
+		pthread_cond_signal(&thr->c);
+		pthread_mutex_unlock(&thr->m);
+
+		pthread_join(thr->t, NULL);
+		pthread_cond_destroy(&thr->c);
+		pthread_mutex_destroy(&thr->m);
+		free(thr);
+
+		pool->count--;
+	}
+	pthread_mutex_unlock(&pool->m);
+
+	pthread_mutex_destroy(&pool->m);
+	pthread_cond_destroy(&pool->c);
+	free(pool);
+
+	*poolp = NULL;
+}
+
+
+/* Resultq */
+
+static struct resultq *
+resultq_init(void)
+{
+	struct resultq *rq = calloc(1, sizeof(*rq));
+
+	pthread_mutex_init(&rq->m, NULL);
+	pthread_cond_init(&rq->c, NULL);
+
+	rq->ptail = &rq->head;
+	return rq;
+}
+
+static bool
+resultq_next(struct resultq *rq, void **res)
+{
+	struct thread *thr = NULL;
+
+	/* Remove thread from queue, if any */
+	pthread_mutex_lock(&rq->m);
+	while (rq->head == NULL && !(rq->finished && rq->nthreads == 0))
+		pthread_cond_wait(&rq->c, &rq->m);
+
+	if (rq->head != NULL) {
+		thr = rq->head;
+		rq->head = thr->next;
+		thr->next = NULL;
+		rq->nthreads--;
+
+		if (rq->head == NULL)
+			rq->ptail = &rq->head;
+	}
+	pthread_mutex_unlock(&rq->m);
+
+	if (thr == NULL)
+		return false;
+
+	/* Wait for thread's result */
+	pthread_mutex_lock(&thr->m);
+	while(thr->running)
+		pthread_cond_wait(&thr->c, &thr->m);
+	*res = thr->res;
+	thr->res = NULL;
+	pthread_mutex_unlock(&thr->m);
+
+	/* Return thread to pool */
+	pthread_mutex_lock(&thr->pool->m);
+	thr->next = thr->pool->head;
+	thr->pool->head = thr;
+	pthread_cond_signal(&thr->pool->c);
+	pthread_mutex_unlock(&thr->pool->m);
+
+	return true;
+}
+
+static void
+resultq_finish(struct resultq *rq)
+{
+	pthread_mutex_lock(&rq->m);
+	rq->finished = true;
+	pthread_cond_signal(&rq->c);
+	pthread_mutex_unlock(&rq->m);
+}
+
+static void
+resultq_destroy(struct resultq **rqp)
+{
+	struct resultq *rq = *rqp;
+
+	if (rq == NULL)
+		return;
+
+	assert(rq->head == NULL && rq->finished && rq->nthreads == 0);
+	pthread_mutex_destroy(&rq->m);
+	pthread_cond_destroy(&rq->c);
+	free(rq);
+	*rqp = NULL;
+}
+
+
+/* Result Handler */
+
+static void *
+result_worker(void *arg)
+{
+	struct result_handler *rh = arg;
+	void *res;
+
+	while (resultq_next(rh->rq, &res))
+		rh->cb(res, rh->cbdata);
+
+	resultq_destroy(&rh->rq);
+
+	return NULL;
+}
+
+struct result_handler *
+result_handler_init(result_cb cb, void *cbdata)
+{
+	struct result_handler *rh = calloc(1, sizeof(*rh));
+
+	rh->rq = resultq_init();
+	rh->cb = cb;
+	rh->cbdata = cbdata;
+	pthread_create(&rh->thread, NULL, result_worker, rh);
+
+	return rh;
+}
+
+void
+result_handler_destroy(struct result_handler **prh)
+{
+	struct result_handler *rh = *prh;
+	if (rh == NULL) return;
+	resultq_finish(rh->rq);
+	pthread_join(rh->thread, NULL);
+	free(rh);
+	*prh = NULL;
+}

--- a/mtbl/threadpool.h
+++ b/mtbl/threadpool.h
@@ -29,10 +29,7 @@ struct threadpool;
  */
 struct threadpool *threadpool_init(size_t max_threads);
 
-/*
- * Destroy a pool of threads, after waiting for all
- * threads to finish.
- */
+/* Destroy a pool of threads, after waiting for all threads to finish. */
 void threadpool_destroy(struct threadpool **poolp);
 
 

--- a/mtbl/threadpool.h
+++ b/mtbl/threadpool.h
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+/* Public interface */
+
+struct mtbl_threadpool {
+	struct threadpool *pool;
+};
+
 /* External API, through mtbl wrapper */
 struct threadpool;
 

--- a/mtbl/threadpool.h
+++ b/mtbl/threadpool.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024 DomainTools LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* External API, through mtbl wrapper */
+struct threadpool;
+
+/*
+ * Initialize a pool of at most `max_threads` threads.
+ * This pool can be passed to multiple thread users.
+ */
+struct threadpool *threadpool_init(size_t max_threads);
+
+/*
+ * Destroy a pool of threads, after waiting for all
+ * threads to finish.
+ */
+void threadpool_destroy(struct threadpool **poolp);
+
+
+/* Internal API. */
+struct result_handler;
+
+typedef void *(*thread_cb)(void *arg);
+typedef void (*result_cb)(void *res, void *cbdata);
+
+/* Initialize a handler for worker thread results. */
+struct result_handler *result_handler_init(result_cb cb, void *cbdata);
+
+/*
+ * threadpool_dispatch runs `cb(arg)` in a thread from pool `pool`,
+ * passing its result to the result handler's callback.
+ *
+ * If `ordered` is true, results will be passed to the result handler
+ * callback in the order `threadpool_dispatch` was called, otherwise
+ * they will be passed as each worker thread finishes.
+ */
+
+void threadpool_dispatch(struct threadpool *pool,
+			 struct result_handler *rh,
+			 bool ordered,
+			 thread_cb cb, void *arg);
+
+/*
+ * Free all resources associated with the result handler *rhp after
+ * waiting for the result handler thread and all worker threads to
+ * finish.
+ */
+void result_handler_destroy(struct result_handler **rhp);

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -8,3 +8,4 @@ test-metadata
 test-sorted-merge
 test-varint
 test-vector
+test-fileset-filter

--- a/t/test-compression.sh
+++ b/t/test-compression.sh
@@ -20,8 +20,23 @@ for compression_type in \
     lz4hc \
     zstd \
 ; do
-    echo "$0: Testing compression type ${compression_type}"
-    "${top_builddir}/t/test-compression" "${compression_type}"
+	for thread_count in \
+		0 \
+		1 \
+		2 \
+		5 \
+		8 \
+		10 \
+		24 \
+		36 \
+		50 \
+		100 \
+		500 \
+		1000 \
+	; do
+		echo "$0: Testing compression type ${compression_type} ${thread_count}"
+		"${top_builddir}/t/test-compression" "${compression_type}" "${thread_count}"
+	done
 done
 
 exit 0


### PR DESCRIPTION
- Add public mtbl_threadpool API for creating, sharing, and destroying threadpools.
- When passed an mtbl_threadpool, mtbl_writer will send data block compression jobs to worker threads.
- When passed an mtbl_threadpool, mtbl_sorter will dispatch sorting and temporary-file-writing to worker threads.
- Add -t option to mtbl_merge.